### PR TITLE
Refactor Program.cs and add CosmosExplorer.Core project

### DIFF
--- a/docs/dev environment.md
+++ b/docs/dev environment.md
@@ -3,6 +3,7 @@
 ## Requirements
 * NET 8
 * Azure Cosmos DB emulator
+* Visual Studio 2022 or Visual Studio Code
 
 ### How to install Azure NoSQL
 https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-develop-emulator?tabs=docker-windows%2Ccsharp&pivots=api-nosql

--- a/src/CosmosExplorer.Terminal/Program.cs
+++ b/src/CosmosExplorer.Terminal/Program.cs
@@ -1,16 +1,17 @@
-﻿using Microsoft.Azure.Cosmos;
+﻿using CosmosExplorer.Core;
+using Microsoft.Azure.Cosmos;
 
 class Program
 {
-    private const string ConnectionString = "AccountEndpoint=https://host.docker.internal:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+    private const string CONNECTION_STRING = "AccountEndpoint=https://host.docker.internal:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
 
     static async Task Main(string[] args)
     {
-        // Create Cosmos Client.
-        CosmosClient cosmosClient = CreateCosmosClient();
+        // Create a new instance of the CosmosClient class.
+        CosmosExplorerHelper cosmosExplorerHelper = new CosmosExplorerHelper(CONNECTION_STRING);
 
         // Create an iterator to list the databases.
-        FeedIterator<DatabaseProperties> iterator = GetDatabaseIterator(cosmosClient);
+        FeedIterator<DatabaseProperties> iterator = cosmosExplorerHelper.GetDatabaseIterator();
 
         // TODO: Remove this variable, just for test.
         string databaseName = string.Empty;
@@ -18,8 +19,8 @@ class Program
         // Iterate through the databases and print their names.
         while (iterator.HasMoreResults)
         {
-            FeedResponse<DatabaseProperties> response = await iterator.ReadNextAsync();
-            foreach (var database in response)
+            FeedResponse<DatabaseProperties> databases = await iterator.ReadNextAsync();
+            foreach (var database in databases)
             {
                 databaseName = database.Id;
                 Console.WriteLine(database.Id);
@@ -27,7 +28,7 @@ class Program
         }
 
         // Create an iterator to list the containers in the current database.
-        FeedIterator<ContainerProperties> containerIterator = GetContainerIterator(cosmosClient, databaseName);
+        FeedIterator<ContainerProperties> containerIterator = cosmosExplorerHelper.GetContainerIterator(databaseName);
 
         // Iterate through the containers and print their names.
         while (containerIterator.HasMoreResults)
@@ -41,12 +42,12 @@ class Program
 
         // Run a query in a specific container.
         databaseName = "Oversight";
-        string containerName = "Project"; 
-        Container containerQuery = cosmosClient.GetContainer(databaseName, containerName);
+        string containerName = "Project";
 
         // Define the query
         string query = "SELECT * FROM c WHERE c.ProjectId = '45345345asdfs'"; // Replace with your query
-        FeedIterator<dynamic> queryIterator = containerQuery.GetItemQueryIterator<dynamic>(new QueryDefinition(query));
+
+        FeedIterator<dynamic> queryIterator = cosmosExplorerHelper.GetQueryIterator(databaseName, containerName, query);
 
         // Iterate through the query results and print them
         while (queryIterator.HasMoreResults)
@@ -57,61 +58,5 @@ class Program
                 Console.WriteLine(item);
             }
         }
-    }
-
-    /// <summary>
-    /// Creates a new instance of the <see cref="CosmosClient"/> class with custom options.
-    /// This method configures the client to accept self-signed certificates in development.
-    /// </summary>
-    /// <returns>A configured <see cref="CosmosClient"/> instance.</returns>
-    private static CosmosClient CreateCosmosClient()
-    {
-        // This is a workaround to accept self-signed certificates in development.
-        CosmosClientOptions options = new()
-        {
-            HttpClientFactory = () => new HttpClient(new HttpClientHandler()
-            {
-                ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-            }),
-            ConnectionMode = ConnectionMode.Gateway,
-        };
-
-        return new CosmosClient(ConnectionString, clientOptions: options);
-    }
-
-    /// <summary>
-    /// Gets an iterator to list the databases in the Cosmos DB account.
-    /// </summary>
-    /// <param name="cosmosClient">The <see cref="CosmosClient"/> instance to use for querying databases.</param>
-    /// <returns>A <see cref="FeedIterator{DatabaseProperties}"/> to iterate through the databases.</returns>
-    private static FeedIterator<DatabaseProperties> GetDatabaseIterator(CosmosClient cosmosClient)
-    {
-        return cosmosClient.GetDatabaseQueryIterator<DatabaseProperties>();
-    }
-
-    /// <summary>
-    /// Gets an iterator to list the containers in a specific database.
-    /// </summary>
-    /// <param name="cosmosClient">The <see cref="CosmosClient"/> instance to use for querying containers.</param>
-    /// <param name="databaseName">The name of the database to list containers from.</param>
-    /// <returns>A <see cref="FeedIterator{ContainerProperties}"/> to iterate through the containers.</returns>
-    private static FeedIterator<ContainerProperties> GetContainerIterator(CosmosClient cosmosClient, string databaseName)
-    {
-        Database database = cosmosClient.GetDatabase(databaseName);
-        return database.GetContainerQueryIterator<ContainerProperties>();
-    }
-
-    /// <summary>
-    /// Gets an iterator to run a query in a specific container.
-    /// </summary>
-    /// <param name="cosmosClient">The <see cref="CosmosClient"/> instance to use for querying items.</param>
-    /// <param name="databaseName">The name of the database containing the container.</param>
-    /// <param name="containerName">The name of the container to run the query against.</param>
-    /// <param name="query">The query to execute.</param>
-    /// <returns>A <see cref="FeedIterator{T}"/> to iterate through the query results.</returns>
-    private static FeedIterator<dynamic> GetQueryIterator(CosmosClient cosmosClient, string databaseName, string containerName, string query)
-    {
-        Container containerQuery = cosmosClient.GetContainer(databaseName, containerName);
-        return containerQuery.GetItemQueryIterator<dynamic>(new QueryDefinition(query));
     }
 }

--- a/src/CosmosExplorer.sln
+++ b/src/CosmosExplorer.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.12.35417.141 d17.12
+VisualStudioVersion = 17.12.35417.141
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CosmosExplorer.Terminal", "CosmosExplorer.Terminal\CosmosExplorer.Terminal.csproj", "{3C40D54F-64E6-49F7-B813-FDF6C1B2808A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CosmosExplorer.Core", "CosmosExplorer\CosmosExplorer.Core.csproj", "{37595716-EE6A-4CCD-A639-BB0038B5D2DC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{3C40D54F-64E6-49F7-B813-FDF6C1B2808A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3C40D54F-64E6-49F7-B813-FDF6C1B2808A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3C40D54F-64E6-49F7-B813-FDF6C1B2808A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{37595716-EE6A-4CCD-A639-BB0038B5D2DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{37595716-EE6A-4CCD-A639-BB0038B5D2DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{37595716-EE6A-4CCD-A639-BB0038B5D2DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{37595716-EE6A-4CCD-A639-BB0038B5D2DC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/CosmosExplorer/CosmosExplorer.Core.csproj
+++ b/src/CosmosExplorer/CosmosExplorer.Core.csproj
@@ -1,21 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.45.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\CosmosExplorer\CosmosExplorer.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/CosmosExplorer/CosmosExplorerHelper.cs
+++ b/src/CosmosExplorer/CosmosExplorerHelper.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.Azure.Cosmos;
+
+namespace CosmosExplorer.Core
+{
+    public class CosmosExplorerHelper
+    {
+        private readonly CosmosClient _cosmosClient;
+
+        public CosmosExplorerHelper(string connectionString)
+        {
+            _cosmosClient = CreateCosmosClient(connectionString);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="CosmosClient"/> class with the specified connection string.
+        /// This method configures the client to accept self-signed certificates in development environments.
+        /// </summary>
+        /// <param name="connectionString">The connection string to use for the Cosmos DB account.</param>
+        /// <returns>A new instance of the <see cref="CosmosClient"/> class.</returns>
+        public CosmosClient CreateCosmosClient(string connectionString)
+        {
+            // This is a workaround to accept self-signed certificates in development.
+            CosmosClientOptions options = new()
+            {
+                HttpClientFactory = () => new HttpClient(new HttpClientHandler()
+                {
+                    ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+                }),
+                ConnectionMode = ConnectionMode.Gateway,
+            };
+
+            return new CosmosClient(connectionString, clientOptions: options);
+        }
+
+        /// <summary>
+        /// Gets an iterator to list the databases in the Cosmos DB account.
+        /// </summary>
+        /// <returns>A <see cref="FeedIterator{DatabaseProperties}"/> to iterate through the databases.</returns>
+        public FeedIterator<DatabaseProperties> GetDatabaseIterator()
+        {
+            return _cosmosClient.GetDatabaseQueryIterator<DatabaseProperties>();
+        }
+
+        /// <summary>
+        /// Gets an iterator to list the containers in a specific database.
+        /// </summary>
+        /// <param name="databaseName">The name of the database to list containers from.</param>
+        /// <returns>A <see cref="FeedIterator{ContainerProperties}"/> to iterate through the containers.</returns>
+        public FeedIterator<ContainerProperties> GetContainerIterator(string databaseName)
+        {
+            Database database = _cosmosClient.GetDatabase(databaseName);
+            return database.GetContainerQueryIterator<ContainerProperties>();
+        }
+
+        /// <summary>
+        /// Gets an iterator to run a query in a specific container.
+        /// </summary>
+        /// <param name="databaseName">The name of the database containing the container.</param>
+        /// <param name="containerName">The name of the container to run the query against.</param>
+        /// <param name="query">The query to execute.</param>
+        /// <returns>A <see cref="FeedIterator{T}"/> to iterate through the query results.</returns>
+        public FeedIterator<dynamic> GetQueryIterator(string databaseName, string containerName, string query)
+        {
+            Container containerQuery = _cosmosClient.GetContainer(databaseName, containerName);
+            return containerQuery.GetItemQueryIterator<dynamic>(new QueryDefinition(query));
+        }
+    }
+}


### PR DESCRIPTION
Refactor Program.cs and add CosmosExplorer.Core project

Updated dev environment.md to include Visual Studio 2022 or VS Code as requirements. Modified CosmosExplorer.Terminal.csproj to add references to Newtonsoft.Json and CosmosExplorer.Core.csproj. Refactored Program.cs to use CosmosExplorerHelper from CosmosExplorer.Core, including replacing direct usage of CosmosClient, changing ConnectionString to CONNECTION_STRING, and removing several methods. Updated CosmosExplorer.sln to include CosmosExplorer.Core project. Added new CosmosExplorer.Core.csproj with references to Microsoft.Azure.Cosmos and Newtonsoft.Json. Added CosmosExplorerHelper class to encapsulate CosmosClient logic.