### PR TITLE
Refactor item creation to upsert in Cosmos DB

### DIFF
--- a/docs/next features.md
+++ b/docs/next features.md
@@ -1,4 +1,3 @@
 # Next features:
 
-* Edit document
 * Delete document

--- a/src/CosmosExplorer.Terminal/Program.cs
+++ b/src/CosmosExplorer.Terminal/Program.cs
@@ -17,7 +17,7 @@ class Program
             Console.WriteLine("1) See all databases");
             Console.WriteLine("2) See all containers by a database");
             Console.WriteLine("3) Run a query by a database and a container");
-            Console.WriteLine("4) Create an item by a database, container and the item");
+            Console.WriteLine("4) Create or replace an item by a database, container and the item");
             Console.WriteLine("5) Exit");
             string option = Console.ReadLine();
 
@@ -95,11 +95,6 @@ class Program
         }
     }
 
-    /// <summary>
-    /// Creates an item in the specified container within the specified database.
-    /// </summary>
-    /// <param name="cosmosExplorerHelper">The helper instance to interact with Cosmos DB.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
     private static async Task CreateItemByDatabaseAndContainer(CosmosExplorerCore cosmosExplorerHelper)
     {
         Console.Write("Enter database name: ");
@@ -116,7 +111,7 @@ class Program
 
         dynamic item = Newtonsoft.Json.JsonConvert.DeserializeObject(itemJson);
 
-        dynamic createdItem = await cosmosExplorerHelper.CreateItemAsync(databaseName, containerName, item, partitionKey);
+        dynamic createdItem = await cosmosExplorerHelper.UpsertItemAsync(databaseName, containerName, item, partitionKey);
 
         Console.WriteLine($"Created item: {createdItem}");
     }

--- a/src/CosmosExplorer/CosmosExplorerCore.cs
+++ b/src/CosmosExplorer/CosmosExplorerCore.cs
@@ -66,17 +66,18 @@ namespace CosmosExplorer.Core
         }
 
         /// <summary>
-        /// Creates an item in the specified container within the specified database.
+        /// Upserts an item in the specified container within the specified database.
+        /// If the item does not exist, it will be created. If it exists, it will be updated.
         /// </summary>
         /// <param name="databaseName">The name of the database containing the container.</param>
-        /// <param name="containerName">The name of the container to create the item in.</param>
-        /// <param name="item">The item to create in the container.</param>
+        /// <param name="containerName">The name of the container to upsert the item into.</param>
+        /// <param name="item">The item to upsert.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
-        /// <returns>A task representing the asynchronous operation, with a dynamic result containing the created item.</returns>
-        public async Task<dynamic> CreateItemAsync(string databaseName, string containerName, dynamic item, string partitionKey)
+        /// <returns>A task representing the asynchronous operation, with a dynamic result containing the upserted item.</returns>
+        public async Task<dynamic> UpsertItemAsync(string databaseName, string containerName, dynamic item, string partitionKey)
         {
             Container container = _cosmosClient.GetContainer(databaseName, containerName);
-            return await container.CreateItemAsync(item, new PartitionKey(partitionKey)).ConfigureAwait(false);
+            return await container.UpsertItemAsync(item, new PartitionKey(partitionKey)).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Refactor item creation to upsert in Cosmos DB

Updated `next features.md` to remove "Edit document" and "Delete document" features.
Changed menu option text in `Program.cs` to "Create or replace an item by a database, container and the item".
Modified `CreateItemByDatabaseAndContainer` method in `Program.cs` to use `UpsertItemAsync` instead of `CreateItemAsync`.
Updated `CosmosExplorerCore.cs` to replace `CreateItemAsync` with `UpsertItemAsync`, including method summary and parameter descriptions.
Changed method implementation to call `UpsertItemAsync` on the container.