### PR TITLE
Add delete item feature and update console menu

### DIFF
--- a/docs/next features.md
+++ b/docs/next features.md
@@ -1,3 +1,4 @@
 # Next features:
 
-* Delete document
+* Create container
+* Delete container

--- a/src/CosmosExplorer.Terminal/Program.cs
+++ b/src/CosmosExplorer.Terminal/Program.cs
@@ -18,7 +18,8 @@ class Program
             Console.WriteLine("2) See all containers by a database");
             Console.WriteLine("3) Run a query by a database and a container");
             Console.WriteLine("4) Create or replace an item by a database, container and the item");
-            Console.WriteLine("5) Exit");
+            Console.WriteLine("5) Delete an item by database, container, id and partitionKey");
+            Console.WriteLine("6) Exit");
             string option = Console.ReadLine();
 
             switch (option)
@@ -36,6 +37,9 @@ class Program
                     await CreateItemByDatabaseAndContainer(cosmosExplorerHelper);
                     break;
                 case "5":
+                    await DeleteItemByDatabaseAndContainer(cosmosExplorerHelper);
+                    break;
+                case "6":
                     return;
                 default:
                     Console.WriteLine("Invalid option. Please try again.");
@@ -114,5 +118,24 @@ class Program
         dynamic createdItem = await cosmosExplorerHelper.UpsertItemAsync(databaseName, containerName, item, partitionKey);
 
         Console.WriteLine($"Created item: {createdItem}");
+    }
+
+    private static async Task DeleteItemByDatabaseAndContainer(CosmosExplorerCore cosmosExplorerHelper)
+    {
+        Console.Write("Enter database name: ");
+        string databaseName = Console.ReadLine();
+
+        Console.Write("Enter container name: ");
+        string containerName = Console.ReadLine();
+
+        Console.Write("Enter item id: ");
+        string id = Console.ReadLine();
+
+        Console.Write("Enter partition key: ");
+        string partitionKey = Console.ReadLine();
+
+        dynamic deletedItem = await cosmosExplorerHelper.DeleteItemAsync(databaseName, containerName, id, partitionKey);
+
+        Console.WriteLine($"Deleted item: {deletedItem}");
     }
 }

--- a/src/CosmosExplorer/CosmosExplorerCore.cs
+++ b/src/CosmosExplorer/CosmosExplorerCore.cs
@@ -79,5 +79,19 @@ namespace CosmosExplorer.Core
             Container container = _cosmosClient.GetContainer(databaseName, containerName);
             return await container.UpsertItemAsync(item, new PartitionKey(partitionKey)).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Deletes an item from the specified container within the specified database.
+        /// </summary>
+        /// <param name="databaseName">The name of the database containing the container.</param>
+        /// <param name="containerName">The name of the container to delete the item from.</param>
+        /// <param name="id">The ID of the item to delete.</param>
+        /// <param name="partitionKey">The partition key for the item.</param>
+        /// <returns>A task representing the asynchronous operation, with a dynamic result containing the deleted item.</returns>
+        public async Task<dynamic> DeleteItemAsync(string databaseName, string containerName, string id, string partitionKey)
+        {
+            Container container = _cosmosClient.GetContainer(databaseName, containerName);
+            return await container.DeleteItemAsync<dynamic>(id, new PartitionKey(partitionKey)).ConfigureAwait(false);
+        }
     }
 }


### PR DESCRIPTION
Add delete item feature and update console menu

- Updated `next features.md` to include "Create container" and "Delete container" features; removed "Delete document" feature.
- Updated console menu in `Program.cs`: moved "Exit" to position 6, added "Delete an item by database, container, id and partitionKey" at position 5.
- Added `DeleteItemByDatabaseAndContainer` method in `Program.cs` to handle item deletion.
- Added `DeleteItemAsync` method in `CosmosExplorerCore.cs` to delete items from a specified container and database.