### PR TITLE
Expand UI and functionality for database operations

### DIFF
--- a/src/CosmosExplorer.UI/MainWindow.xaml
+++ b/src/CosmosExplorer.UI/MainWindow.xaml
@@ -1,20 +1,22 @@
 ﻿<Window x:Class="CosmosExplorer.UI.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Cosmos Explorer (Preview)" Height="450" Width="800">
+        Title="Cosmos Explorer (Preview)" Height="800" Width="1800">
     <Grid>
         <StackPanel>
-            <TextBox x:Name="ConnectionStringTextBox" Width="400" Margin="10" Text="Enter the connection string" Foreground="Gray"/>
-            <Button Content="Connect" Width="100" Margin="10" Click="ConnectButton_Click"/>
-            <ComboBox x:Name="OptionsComboBox" Width="400" Margin="10">
+            <StackPanel Width="1600" Orientation="Horizontal">
+                <TextBox x:Name="ConnectionStringTextBox" Width="1400" Margin="10" Text="Enter the connection string" Foreground="Gray" HorizontalAlignment="Left" FontSize="18"/>
+                <Button Content="Connect" Width="100" Margin="10" Click="ConnectButton_Click" HorizontalAlignment="Right" FontSize="18"/>
+            </StackPanel>
+            <ComboBox x:Name="OptionsComboBox" Width="600" Margin="10" FontSize="18">
                 <ComboBoxItem Content="See all databases"/>
                 <ComboBoxItem Content="See all containers by a database"/>
                 <ComboBoxItem Content="Run a query by a database and a container"/>
                 <ComboBoxItem Content="Create or replace an item by a database, container and the item"/>
                 <ComboBoxItem Content="Delete an item by database, container, id and partitionKey"/>
             </ComboBox>
-            <Button Content="Execute" Width="100" Margin="10" Click="ExecuteButton_Click"/>
-            <TextBox x:Name="OutputTextBox" Width="400" Height="200" Margin="10" IsReadOnly="True" TextWrapping="Wrap"/>
+            <Button Content="Execute" Width="100" Margin="10" Click="ExecuteButton_Click" FontSize="18"/>
+            <TextBox x:Name="OutputTextBox" Width="1000" Height="400" Margin="10" IsReadOnly="True" TextWrapping="Wrap" FontSize="18"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/src/CosmosExplorer.UI/MainWindow.xaml.cs
+++ b/src/CosmosExplorer.UI/MainWindow.xaml.cs
@@ -216,11 +216,12 @@ namespace CosmosExplorer.UI
                         Title = "Enter Query",
                         Width = 400,
                         Height = 200,
-                        WindowStartupLocation = WindowStartupLocation.CenterScreen
+                        WindowStartupLocation = WindowStartupLocation.CenterScreen,
+                        
                     };
 
                     var queryStackPanel = new StackPanel();
-                    var queryTextBox = new TextBox { Margin = new Thickness(10), AcceptsReturn = true, Height = 100 };
+                    var queryTextBox = new TextBox { Margin = new Thickness(10), AcceptsReturn = true, Height = 100, Text = "Select * from c" };
 
                     var queryOkButton = new Button
                     {
@@ -260,12 +261,269 @@ namespace CosmosExplorer.UI
 
         private async Task CreateItemByDatabaseAndContainer()
         {
-            OutputTextBox.Text = "This will be available soon";
+            OutputTextBox.Text = string.Empty;
+
+            List<string> databaseNames = await GetDatabases().ConfigureAwait(true);
+
+            var selectDatabaseWindow = new Window
+            {
+                Title = "Select Database",
+                Width = 300,
+                Height = 150,
+                WindowStartupLocation = WindowStartupLocation.CenterScreen
+            };
+
+            var stackPanel = new StackPanel();
+            var comboBox = new ComboBox { Margin = new Thickness(10) };
+            foreach (var dbName in databaseNames)
+            {
+                comboBox.Items.Add(new ComboBoxItem { Content = dbName });
+            }
+            comboBox.SelectedIndex = 0;
+
+            var okButton = new Button
+            {
+                Content = "OK",
+                Width = 75,
+                Margin = new Thickness(10),
+                HorizontalAlignment = HorizontalAlignment.Right
+            };
+            okButton.Click += (s, e) => selectDatabaseWindow.DialogResult = true;
+
+            stackPanel.Children.Add(comboBox);
+            stackPanel.Children.Add(okButton);
+            selectDatabaseWindow.Content = stackPanel;
+
+            if (selectDatabaseWindow.ShowDialog() == true)
+            {
+                string databaseName = ((ComboBoxItem)comboBox.SelectedItem).Content.ToString();
+                if (string.IsNullOrEmpty(databaseName))
+                {
+                    OutputTextBox.Text = "Database name cannot be empty.";
+                    return;
+                }
+
+                var selectContainerWindow = new Window
+                {
+                    Title = "Select Container",
+                    Width = 300,
+                    Height = 150,
+                    WindowStartupLocation = WindowStartupLocation.CenterScreen
+                };
+
+                var containerStackPanel = new StackPanel();
+                var containerComboBox = new ComboBox { Margin = new Thickness(10) };
+
+                FeedIterator<ContainerProperties> containerIterator = _cosmosExplorerHelper.GetContainerIterator(databaseName);
+                while (containerIterator.HasMoreResults)
+                {
+                    FeedResponse<ContainerProperties> containerResponse = await containerIterator.ReadNextAsync().ConfigureAwait(true);
+                    foreach (var container in containerResponse)
+                    {
+                        containerComboBox.Items.Add(new ComboBoxItem { Content = container.Id });
+                    }
+                }
+                containerComboBox.SelectedIndex = 0;
+
+                var containerOkButton = new Button
+                {
+                    Content = "OK",
+                    Width = 75,
+                    Margin = new Thickness(10),
+                    HorizontalAlignment = HorizontalAlignment.Right
+                };
+                containerOkButton.Click += (s, e) => selectContainerWindow.DialogResult = true;
+
+                containerStackPanel.Children.Add(containerComboBox);
+                containerStackPanel.Children.Add(containerOkButton);
+                selectContainerWindow.Content = containerStackPanel;
+
+                if (selectContainerWindow.ShowDialog() == true)
+                {
+                    string containerName = ((ComboBoxItem)containerComboBox.SelectedItem).Content.ToString();
+                    if (string.IsNullOrEmpty(containerName))
+                    {
+                        OutputTextBox.Text = "Container name cannot be empty.";
+                        return;
+                    }
+
+                    var itemWindow = new Window
+                    {
+                        Title = "Enter Item",
+                        Width = 400,
+                        Height = 300,
+                        WindowStartupLocation = WindowStartupLocation.CenterScreen
+                    };
+
+                    var itemStackPanel = new StackPanel();
+                    var itemTextBox = new TextBox { Margin = new Thickness(10), AcceptsReturn = true, Height = 150 };
+                    var partitionKeyTextBox = new TextBox { Margin = new Thickness(10), Height = 30, Text = "Enter partition key" };
+
+                    var itemOkButton = new Button
+                    {
+                        Content = "OK",
+                        Width = 75,
+                        Margin = new Thickness(10),
+                        HorizontalAlignment = HorizontalAlignment.Right
+                    };
+                    itemOkButton.Click += (s, e) => itemWindow.DialogResult = true;
+
+                    itemStackPanel.Children.Add(itemTextBox);
+                    itemStackPanel.Children.Add(partitionKeyTextBox);
+                    itemStackPanel.Children.Add(itemOkButton);
+                    itemWindow.Content = itemStackPanel;
+
+                    if (itemWindow.ShowDialog() == true)
+                    {
+                        string itemJson = itemTextBox.Text;
+                        string partitionKey = partitionKeyTextBox.Text;
+
+                        if (string.IsNullOrEmpty(itemJson) || string.IsNullOrEmpty(partitionKey))
+                        {
+                            OutputTextBox.Text = "Item and partition key cannot be empty.";
+                            return;
+                        }
+
+                        dynamic item = Newtonsoft.Json.JsonConvert.DeserializeObject(itemJson);
+                        dynamic createdItem = await _cosmosExplorerHelper.UpsertItemAsync(databaseName, containerName, item, partitionKey);
+
+                        OutputTextBox.Text = $"Created item: {createdItem}";
+                    }
+                }
+            }
         }
 
         private async Task DeleteItemByDatabaseAndContainer()
         {
-            OutputTextBox.Text = "This will be available soon";
+            OutputTextBox.Text = string.Empty;
+
+            List<string> databaseNames = await GetDatabases().ConfigureAwait(true);
+
+            var selectDatabaseWindow = new Window
+            {
+                Title = "Select Database",
+                Width = 300,
+                Height = 150,
+                WindowStartupLocation = WindowStartupLocation.CenterScreen
+            };
+
+            var stackPanel = new StackPanel();
+            var comboBox = new ComboBox { Margin = new Thickness(10) };
+            foreach (var dbName in databaseNames)
+            {
+                comboBox.Items.Add(new ComboBoxItem { Content = dbName });
+            }
+            comboBox.SelectedIndex = 0;
+
+            var okButton = new Button
+            {
+                Content = "OK",
+                Width = 75,
+                Margin = new Thickness(10),
+                HorizontalAlignment = HorizontalAlignment.Right
+            };
+            okButton.Click += (s, e) => selectDatabaseWindow.DialogResult = true;
+
+            stackPanel.Children.Add(comboBox);
+            stackPanel.Children.Add(okButton);
+            selectDatabaseWindow.Content = stackPanel;
+
+            if (selectDatabaseWindow.ShowDialog() == true)
+            {
+                string databaseName = ((ComboBoxItem)comboBox.SelectedItem).Content.ToString();
+                if (string.IsNullOrEmpty(databaseName))
+                {
+                    OutputTextBox.Text = "Database name cannot be empty.";
+                    return;
+                }
+
+                var selectContainerWindow = new Window
+                {
+                    Title = "Select Container",
+                    Width = 300,
+                    Height = 150,
+                    WindowStartupLocation = WindowStartupLocation.CenterScreen
+                };
+
+                var containerStackPanel = new StackPanel();
+                var containerComboBox = new ComboBox { Margin = new Thickness(10) };
+
+                FeedIterator<ContainerProperties> containerIterator = _cosmosExplorerHelper.GetContainerIterator(databaseName);
+                while (containerIterator.HasMoreResults)
+                {
+                    FeedResponse<ContainerProperties> containerResponse = await containerIterator.ReadNextAsync().ConfigureAwait(true);
+                    foreach (var container in containerResponse)
+                    {
+                        containerComboBox.Items.Add(new ComboBoxItem { Content = container.Id });
+                    }
+                }
+                containerComboBox.SelectedIndex = 0;
+
+                var containerOkButton = new Button
+                {
+                    Content = "OK",
+                    Width = 75,
+                    Margin = new Thickness(10),
+                    HorizontalAlignment = HorizontalAlignment.Right
+                };
+                containerOkButton.Click += (s, e) => selectContainerWindow.DialogResult = true;
+
+                containerStackPanel.Children.Add(containerComboBox);
+                containerStackPanel.Children.Add(containerOkButton);
+                selectContainerWindow.Content = containerStackPanel;
+
+                if (selectContainerWindow.ShowDialog() == true)
+                {
+                    string containerName = ((ComboBoxItem)containerComboBox.SelectedItem).Content.ToString();
+                    if (string.IsNullOrEmpty(containerName))
+                    {
+                        OutputTextBox.Text = "Container name cannot be empty.";
+                        return;
+                    }
+
+                    var itemWindow = new Window
+                    {
+                        Title = "Enter Item Details",
+                        Width = 400,
+                        Height = 200,
+                        WindowStartupLocation = WindowStartupLocation.CenterScreen
+                    };
+
+                    var itemStackPanel = new StackPanel();
+                    var idTextBox = new TextBox { Margin = new Thickness(10), Height = 30, Text = "Enter item id" };
+                    var partitionKeyTextBox = new TextBox { Margin = new Thickness(10), Height = 30, Text = "Enter partition key" };
+
+                    var itemOkButton = new Button
+                    {
+                        Content = "OK",
+                        Width = 75,
+                        Margin = new Thickness(10),
+                        HorizontalAlignment = HorizontalAlignment.Right
+                    };
+                    itemOkButton.Click += (s, e) => itemWindow.DialogResult = true;
+
+                    itemStackPanel.Children.Add(idTextBox);
+                    itemStackPanel.Children.Add(partitionKeyTextBox);
+                    itemStackPanel.Children.Add(itemOkButton);
+                    itemWindow.Content = itemStackPanel;
+
+                    if (itemWindow.ShowDialog() == true)
+                    {
+                        string id = idTextBox.Text;
+                        string partitionKey = partitionKeyTextBox.Text;
+
+                        if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(partitionKey))
+                        {
+                            OutputTextBox.Text = "Item id and partition key cannot be empty.";
+                            return;
+                        }
+
+                        dynamic deletedItem = await _cosmosExplorerHelper.DeleteItemAsync(databaseName, containerName, id, partitionKey).ConfigureAwait(true);
+
+                        OutputTextBox.Text = $"Deleted item: {deletedItem}";
+                    }
+                }
+            }
         }
 
         private async Task<List<string>> GetDatabases()


### PR DESCRIPTION
Expand UI and functionality for database operations

Increased window size in MainWindow.xaml to 800x1800. Modified StackPanel to horizontal orientation with a width of 1600, TextBox width to 1400, and aligned Button to the right. Updated font size to 18 for TextBox, Button, ComboBox, Execute button, and OutputTextBox. Widened ComboBox to 600. Increased OutputTextBox size to 1000x400.

Added default query text "Select * from c" to queryTextBox in MainWindow.xaml.cs. Expanded CreateItemByDatabaseAndContainer and DeleteItemByDatabaseAndContainer methods to include windows for selecting database, container, and entering item details. Added logic for creating, upserting, and deleting items. Both methods now clear OutputTextBox before operations. Added helper methods and UI elements for new functionality.