### PR TITLE
Add Chocolatey deployment docs and minor UI doc fix

### DIFF
--- a/docs/dev environment.md
+++ b/docs/dev environment.md
@@ -32,3 +32,56 @@ mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest
 1. Install Azure cosmos DB Emulator
 2. Select CosmosExplorer.UI as startup project
 3. F5
+
+## How to deploy (Chocolatey)
+1) choco new cosmosexplorer (just the first time)
+move to C:\Windows\System32\{packagename}
+
+delete TODO, 
+2) Adjust .nuspec file
+
+Example 
+```
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>cosmosexplorer</id>
+    <version>1.0.0</version>
+    <owners>Javier Leyes</owners>
+    <title>Cosmos Explorer</title>
+    <authors>Javier Leyes</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/javierleyes/CosmosExplorer/blob/main/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/javierleyes/CosmosExplorer</projectUrl>
+    <packageSourceUrl>https://github.com/javierleyes/CosmosExplorer</packageSourceUrl>
+    <copyright>Copyright 2024 Javier Leyes</copyright>
+    <projectSourceUrl>https://github.com/javierleyes/CosmosExplorer</projectSourceUrl>
+    <docsUrl>https://github.com/javierleyes/CosmosExplorer/tree/main/docs</docsUrl>
+    <bugTrackerUrl>https://github.com/javierleyes/CosmosExplorer/issues</bugTrackerUrl>
+    <tags>cosmosexplorer azure cosmos nosql</tags>
+    <summary>Cosmos Explorer allows users to manage data like Azure Portal</summary>
+    <description>Cosmos Explorer allows users to manage data like Azure Portal</description>
+    <releaseNotes>https://github.com/javierleyes/CosmosExplorer/blob/main/docs/release%20notes.md</releaseNotes>
+  </metadata>
+    <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>
+```
+
+3) Adjust chocolateyinstall.ps1
+```
+$ErrorActionPreference = 'Stop' # stop on all errors
+Install-ChocolateyInstallPackage $env:ChocolateyPackageName 'exe' '/VERYSILENT' "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)\CosmosExplorer.UI.exe"
+```
+
+# Generate the package
+4) choco pack
+
+# This is to test the package
+5) choco install cosmosexplorer --debug --verbose --source .
+
+6) Upload package
+choco push cosmosexplorer.1.0.0.nupkg --key "your-api-key"
+
+


### PR DESCRIPTION
Add Chocolatey deployment docs and minor UI doc fix

Introduce a new section in the documentation for deploying the Cosmos Explorer using Chocolatey. Steps include creating and configuring a Chocolatey package, modifying installation scripts, and testing and uploading the package. Also, remove a redundant line in the "How to use Cosmos Explorer UI" section.