### PR TITLE
Add DatabaseTreeSource and integrate database loading

### DIFF
--- a/src/CosmosExplorer.UI/Common/DatabaseTreeSource.cs
+++ b/src/CosmosExplorer.UI/Common/DatabaseTreeSource.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.ObjectModel;
+
+namespace CosmosExplorer.UI
+{
+    public class DatabaseTreeSource
+    {
+        public string Name { get; set; }
+    }
+
+    public class DatabaseTreeCollection : ObservableCollection<DatabaseTreeSource>
+    {
+        public void LoadDatabases(List<string> databaseNames)
+        {
+            foreach (var databaseName in databaseNames)
+            {
+                this.Add(new DatabaseTreeSource { Name = databaseName });
+            }
+        }
+    }
+}

--- a/src/CosmosExplorer.UI/Common/SharedProperties.cs
+++ b/src/CosmosExplorer.UI/Common/SharedProperties.cs
@@ -1,9 +1,30 @@
 ﻿using CosmosExplorer.Core;
+using Microsoft.Azure.Cosmos;
 
 namespace CosmosExplorer.UI.Common
 {
     public static class SharedProperties
     {
         public static CosmosExplorerCore CosmosExplorerCore { get; set; }
+
+        public static DatabaseTreeCollection DatabaseCollection { get; set; }
+
+        public static async Task<List<string>> GetDatabases()
+        {
+            List<string> databaseNames = new List<string>();
+
+            FeedIterator<DatabaseProperties> iterator = CosmosExplorerCore.GetDatabaseIterator();
+
+            while (iterator.HasMoreResults)
+            {
+                FeedResponse<DatabaseProperties> databases = await iterator.ReadNextAsync().ConfigureAwait(true);
+                foreach (var database in databases)
+                {
+                    databaseNames.Add(database.Id);
+                }
+            }
+
+            return databaseNames;
+        }
     }
 }

--- a/src/CosmosExplorer.UI/CosmosExplorer.UI.csproj
+++ b/src/CosmosExplorer.UI/CosmosExplorer.UI.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="icons\Cosmos-DB.ico" />
+    <None Remove="Icons\Cosmos-DB.ico" />
   </ItemGroup>
 
   <ItemGroup>
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Resource Include="icons\Cosmos-DB.ico" />
+    <Resource Include="Icons\Cosmos-DB.ico" />
   </ItemGroup>
 
 </Project>

--- a/src/CosmosExplorer.UI/MainWindow.xaml
+++ b/src/CosmosExplorer.UI/MainWindow.xaml
@@ -1,6 +1,7 @@
 ﻿<Window x:Class="CosmosExplorer.UI.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:CosmosExplorer.UI"
         Title="Cosmos Explorer (Preview)" Height="800" Width="1800"
         Icon="/icons/Cosmos-DB.ico">
     <Grid>
@@ -14,10 +15,10 @@
                 <MenuItem Header="About Cosmos Explorer" Click="AboutMenuItem_Click"/>
             </MenuItem>
         </Menu>
+
         <StackPanel Margin="0,30,0,0">
             <StackPanel x:Name="Actions" Width="900" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,10" IsEnabled="False">
                 <ComboBox x:Name="OptionsComboBox" Width="600" Margin="10" FontSize="18">
-                    <ComboBoxItem Content="See all databases"/>
                     <ComboBoxItem Content="See all containers by a database"/>
                     <ComboBoxItem Content="Run a query by a database and a container"/>
                     <ComboBoxItem Content="Create or replace an item by a database, container and the item"/>
@@ -26,6 +27,16 @@
                 <Button Content="Execute" Width="100" Margin="10" Click="ExecuteButton_Click" FontSize="18"/>
             </StackPanel>
             <TextBox x:Name="OutputTextBox" Width="1400" Height="400" Margin="10" IsReadOnly="True" TextWrapping="Wrap" FontSize="18" IsEnabled="False"/>
+
+            <!-- TreeView to display database names -->
+            <TreeView x:Name="DatabaseTreeView" Width="400" Height="200" Margin="10">
+                <TreeView.ItemTemplate>
+                    <HierarchicalDataTemplate DataType="{x:Type local:DatabaseTreeSource}" ItemsSource="{Binding}">
+                        <TextBlock Text="{Binding Name}" />
+                    </HierarchicalDataTemplate>
+                </TreeView.ItemTemplate>
+            </TreeView>
+            
         </StackPanel>
     </Grid>
 </Window>

--- a/src/CosmosExplorer.UI/MainWindow.xaml.cs
+++ b/src/CosmosExplorer.UI/MainWindow.xaml.cs
@@ -13,6 +13,8 @@ namespace CosmosExplorer.UI
         public MainWindow()
         {
             InitializeComponent();
+            SharedProperties.DatabaseCollection = new DatabaseTreeCollection();
+            DatabaseTreeView.ItemsSource = SharedProperties.DatabaseCollection;
         }
 
         private void OpenConnectionModal_Click(object sender, RoutedEventArgs e)
@@ -44,9 +46,6 @@ namespace CosmosExplorer.UI
             string selectedOption = ((ComboBoxItem)OptionsComboBox.SelectedItem).Content.ToString();
             switch (selectedOption)
             {
-                case "See all databases":
-                    await SeeAllDatabases().ConfigureAwait(true);
-                    break;
                 case "See all containers by a database":
                     await SeeAllContainersByDatabase().ConfigureAwait(true);
                     break;
@@ -65,21 +64,9 @@ namespace CosmosExplorer.UI
             }
         }
 
-        private async Task SeeAllDatabases()
-        {
-            OutputTextBox.Text = string.Empty;
-
-            List<string> databaseNames = await GetDatabases().ConfigureAwait(true);
-
-            foreach (string databaseName in databaseNames)
-            {
-                OutputTextBox.Text += databaseName + Environment.NewLine;
-            }
-        }
-
         private async Task SeeAllContainersByDatabase()
         {
-            List<string> databaseNames = await GetDatabases().ConfigureAwait(true);
+            List<string> databaseNames = await SharedProperties.GetDatabases().ConfigureAwait(true);
 
             var selectDatabaseWindow = new Window
             {
@@ -136,7 +123,7 @@ namespace CosmosExplorer.UI
         {
             OutputTextBox.Text = string.Empty;
 
-            List<string> databaseNames = await GetDatabases().ConfigureAwait(true);
+            List<string> databaseNames = await SharedProperties.GetDatabases().ConfigureAwait(true);
 
             var selectDatabaseWindow = new Window
             {
@@ -272,7 +259,7 @@ namespace CosmosExplorer.UI
         {
             OutputTextBox.Text = string.Empty;
 
-            List<string> databaseNames = await GetDatabases().ConfigureAwait(true);
+            List<string> databaseNames = await SharedProperties.GetDatabases().ConfigureAwait(true);
 
             var selectDatabaseWindow = new Window
             {
@@ -406,7 +393,7 @@ namespace CosmosExplorer.UI
         {
             OutputTextBox.Text = string.Empty;
 
-            List<string> databaseNames = await GetDatabases().ConfigureAwait(true);
+            List<string> databaseNames = await SharedProperties.GetDatabases().ConfigureAwait(true);
 
             var selectDatabaseWindow = new Window
             {
@@ -533,24 +520,6 @@ namespace CosmosExplorer.UI
                     }
                 }
             }
-        }
-
-        private async Task<List<string>> GetDatabases()
-        {
-            List<string> databaseNames = new List<string>();
-
-            FeedIterator<DatabaseProperties> iterator = SharedProperties.CosmosExplorerCore.GetDatabaseIterator();
-
-            while (iterator.HasMoreResults)
-            {
-                FeedResponse<DatabaseProperties> databases = await iterator.ReadNextAsync().ConfigureAwait(true);
-                foreach (var database in databases)
-                {
-                    databaseNames.Add(database.Id);
-                }
-            }
-
-            return databaseNames;
         }
     }
 }

--- a/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml.cs
+++ b/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml.cs
@@ -15,7 +15,7 @@ namespace CosmosExplorer.UI
             InitializeComponent();
         }
 
-        private void ConnectButton_Click(object sender, RoutedEventArgs e)
+        private async void ConnectButton_Click(object sender, RoutedEventArgs e)
         {
             string connectionString = ConnectionStringTextBox.Text;
             SharedProperties.CosmosExplorerCore = new CosmosExplorerCore(connectionString);
@@ -27,6 +27,10 @@ namespace CosmosExplorer.UI
                 mainWindow.Actions.IsEnabled = true;
                 mainWindow.OutputTextBox.IsEnabled = true;
             }
+
+            List<string> databaseNames = await SharedProperties.GetDatabases().ConfigureAwait(true);
+
+            SharedProperties.DatabaseCollection.LoadDatabases(databaseNames);
 
             // Close the modal
             this.Close();


### PR DESCRIPTION
Add DatabaseTreeSource and integrate database loading

- Added `DatabaseTreeSource` and `DatabaseTreeCollection` classes in `DatabaseTreeSource.cs` to manage database names.
- Updated `SharedProperties.cs` with `DatabaseCollection` and `GetDatabases` method for Azure Cosmos DB.
- Corrected casing of "Icons" directory in `CosmosExplorer.UI.csproj`.
- Added `TreeView` in `MainWindow.xaml` to display database names.
- Initialized `DatabaseCollection` in `MainWindow.xaml.cs` and set `ItemsSource` of `DatabaseTreeView`.
- Made `ConnectButton_Click` async in `ConnectResourceGroupModal.xaml.cs` to load databases into `DatabaseCollection`.