### PR TITLE
Refactor main window layout and enhance UI components

### DIFF
--- a/src/CosmosExplorer.UI/MainWindow.xaml
+++ b/src/CosmosExplorer.UI/MainWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:CosmosExplorer.UI"
-        Title="Cosmos Explorer (Preview)" Height="800" Width="1800"
+        Title="Cosmos Explorer (Preview)" Height="1000" Width="1800"
         Icon="/icons/Cosmos-DB.ico">
     <Grid>
         <Menu VerticalAlignment="Top">
@@ -16,36 +16,42 @@
             </MenuItem>
         </Menu>
 
-        <StackPanel Margin="0,30,0,0">
-            <StackPanel x:Name="Actions" Width="900" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,10" IsEnabled="False">
-                <ComboBox x:Name="OptionsComboBox" Width="600" Margin="10" FontSize="18">
-                    <ComboBoxItem Content="Run a query by a database and a container"/>
-                    <ComboBoxItem Content="Create or replace an item by a database, container and the item"/>
-                    <ComboBoxItem Content="Delete an item by database, container, id and partitionKey"/>
-                </ComboBox>
-                <Button Content="Execute" Width="100" Margin="10" Click="ExecuteButton_Click" FontSize="18"/>
+        <StackPanel Orientation="Horizontal" Margin="30,45,30,45">
+
+            <StackPanel x:Name="LeftPanel" IsEnabled="False" Width="300" Height="800" HorizontalAlignment="Left" VerticalAlignment="Top">
+                <TreeView x:Name="DatabaseTreeView" Width="300" Height="800">
+                    <TreeView.ItemTemplate>
+                        <HierarchicalDataTemplate DataType="{x:Type local:DatabaseTreeSource}" ItemsSource="{Binding Containers}">
+                            <StackPanel Orientation="Horizontal" Margin="0,0,8,8">
+                                <Image Source="/icons/Cosmos-DB.ico" Width="16" Height="16" />
+                                <TextBlock Text="{Binding Name}" Margin="7,0,0,0" FontSize="16" />
+                            </StackPanel>
+                            <HierarchicalDataTemplate.ItemTemplate>
+                                <DataTemplate DataType="{x:Type local:ContainerTreeSource}">
+                                    <StackPanel Orientation="Horizontal" Margin="0,0,8,8">
+                                        <Image Source="/icons/Container.ico" Width="16" Height="16" />
+                                        <TextBlock Text="{Binding Name}" Margin="7,0,0,0" FontSize="16" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </HierarchicalDataTemplate.ItemTemplate>
+                        </HierarchicalDataTemplate>
+                    </TreeView.ItemTemplate>
+                </TreeView>
             </StackPanel>
-            <TextBox x:Name="OutputTextBox" Width="1400" Height="400" Margin="10" IsReadOnly="True" TextWrapping="Wrap" FontSize="18" IsEnabled="False"/>
 
-            <TreeView x:Name="DatabaseTreeView" Width="400" Height="200" Margin="10">
-                <TreeView.ItemTemplate>
-                    <HierarchicalDataTemplate DataType="{x:Type local:DatabaseTreeSource}" ItemsSource="{Binding Containers}">
-                        <StackPanel Orientation="Horizontal" Margin="0,0,8,8">
-                            <Image Source="/icons/Cosmos-DB.ico" Width="16" Height="16" />
-                            <TextBlock Text="{Binding Name}" Margin="7,0,0,0" FontSize="16" />
-                        </StackPanel>
-                        <HierarchicalDataTemplate.ItemTemplate>
-                            <DataTemplate DataType="{x:Type local:ContainerTreeSource}">
-                                <StackPanel Orientation="Horizontal" Margin="0,0,8,8">
-                                    <Image Source="/icons/Container.ico" Width="16" Height="16" />
-                                    <TextBlock Text="{Binding Name}" Margin="7,0,0,0" FontSize="16" />
-                                </StackPanel>
-                            </DataTemplate>
-                        </HierarchicalDataTemplate.ItemTemplate>
-                    </HierarchicalDataTemplate>
-                </TreeView.ItemTemplate>
-            </TreeView>
+            <StackPanel x:Name="CenterPanel" Orientation="Vertical" VerticalAlignment="Top" Width="1400" Height="800" Margin="20,0,0,0">
 
+                <StackPanel x:Name="Actions" Orientation="Horizontal" VerticalAlignment="Top" Width="1400" IsEnabled="False">
+                    <ComboBox x:Name="OptionsComboBox" Width="1300" Height="40" FontSize="18">
+                        <ComboBoxItem Content="Run a query by a database and a container"/>
+                        <ComboBoxItem Content="Create or replace an item by a database, container and the item"/>
+                        <ComboBoxItem Content="Delete an item by database, container, id and partitionKey"/>
+                    </ComboBox>
+                    <Button Content="Execute" Width="100" Click="ExecuteButton_Click" Height="40" FontSize="18"/>
+                </StackPanel>
+                
+                <TextBox x:Name="OutputTextBox" Width="1400" Height="750" Margin="0,10,0,0" IsReadOnly="True" TextWrapping="Wrap" FontSize="18" IsEnabled="False"/>
+            </StackPanel>
         </StackPanel>
     </Grid>
 </Window>

--- a/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml.cs
+++ b/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml.cs
@@ -25,6 +25,7 @@ namespace CosmosExplorer.UI
                 mainWindow.OutputTextBox.Text = "Connected to Cosmos DB.";
                 mainWindow.Actions.IsEnabled = true;
                 mainWindow.OutputTextBox.IsEnabled = true;
+                mainWindow.LeftPanel.IsEnabled = true;
             }
 
             await SharedProperties.LoadDatabasesAsync().ConfigureAwait(true);


### PR DESCRIPTION
Refactor main window layout and enhance UI components

- Increased main window height from 800 to 1000.
- Moved and restructured action `StackPanel` into new `CenterPanel`.
- Added new `LeftPanel` with `TreeView` for databases and containers.
- Moved `OutputTextBox` to `CenterPanel` and increased its height to 750.
- Removed the old `TreeView` from the main window.
- Enabled `LeftPanel` in `ConnectResourceGroupModal.xaml.cs` upon Cosmos DB connection.