### PR TITLE
Adjust panel widths and add new Items StackPanel

### DIFF
--- a/src/CosmosExplorer.UI/MainWindow.xaml
+++ b/src/CosmosExplorer.UI/MainWindow.xaml
@@ -18,8 +18,8 @@
 
         <StackPanel Orientation="Horizontal" Margin="30,45,30,45">
 
-            <StackPanel x:Name="LeftPanel" IsEnabled="False" Width="300" Height="800" HorizontalAlignment="Left" VerticalAlignment="Top">
-                <TreeView x:Name="DatabaseTreeView" Width="300" Height="800">
+            <StackPanel x:Name="LeftPanel" IsEnabled="False" Width="200" Height="800" HorizontalAlignment="Left" VerticalAlignment="Top">
+                <TreeView x:Name="DatabaseTreeView" Width="200" Height="800">
                     <TreeView.ItemTemplate>
                         <HierarchicalDataTemplate DataType="{x:Type local:DatabaseTreeSource}" ItemsSource="{Binding Containers}">
                             <StackPanel Orientation="Horizontal" Margin="0,0,8,8">
@@ -39,18 +39,33 @@
                 </TreeView>
             </StackPanel>
 
-            <StackPanel x:Name="CenterPanel" Orientation="Vertical" VerticalAlignment="Top" Width="1400" Height="800" Margin="20,0,0,0">
+            <StackPanel x:Name="CenterPanel" Orientation="Vertical" VerticalAlignment="Top" Width="1500" Height="800" Margin="20,0,0,0">
 
-                <StackPanel x:Name="Actions" Orientation="Horizontal" VerticalAlignment="Top" Width="1400" IsEnabled="False">
-                    <ComboBox x:Name="OptionsComboBox" Width="1300" Height="40" FontSize="18">
+                <StackPanel x:Name="Actions" Orientation="Horizontal" VerticalAlignment="Top" Width="1500" IsEnabled="False">
+                    
+                    <ComboBox x:Name="OptionsComboBox" Width="1400" Height="40" FontSize="18">
                         <ComboBoxItem Content="Run a query by a database and a container"/>
                         <ComboBoxItem Content="Create or replace an item by a database, container and the item"/>
                         <ComboBoxItem Content="Delete an item by database, container, id and partitionKey"/>
                     </ComboBox>
+                    
                     <Button Content="Execute" Width="100" Click="ExecuteButton_Click" Height="40" FontSize="18"/>
                 </StackPanel>
-                
-                <TextBox x:Name="OutputTextBox" Width="1400" Height="750" Margin="0,10,0,0" IsReadOnly="True" TextWrapping="Wrap" FontSize="18" IsEnabled="False"/>
+
+                <StackPanel x:Name="Items" Orientation="Horizontal" Width="1500" Height="750" IsEnabled="False" Margin="0,10,0,0">
+
+                    <ListView x:Name="ItemsListView" Width="400" Height="750" >
+                        <ListView.View>
+                            <GridView>
+                                <GridViewColumn Header="Id" DisplayMemberBinding="{Binding Id}" Width="200"/>
+                                <GridViewColumn Header="PartitionKey" DisplayMemberBinding="{Binding PartitionKey}" Width="200"/>
+                            </GridView>
+                        </ListView.View>
+                    </ListView>
+
+                    <TextBox x:Name="OutputTextBox" Width="1080" Height="750" Margin="20,0,0,0" IsReadOnly="True" TextWrapping="Wrap" FontSize="18" IsEnabled="False"/>
+                </StackPanel>
+
             </StackPanel>
         </StackPanel>
     </Grid>


### PR DESCRIPTION
Adjust panel widths and add new Items StackPanel

- Reduced width of LeftPanel and DatabaseTreeView from 300 to 200
- Increased width of CenterPanel and Actions from 1400 to 1500
- Increased width of OptionsComboBox from 1300 to 1400
- Added "Execute" button to Actions StackPanel
- Moved OutputTextBox to new Items StackPanel
- Added Items StackPanel with horizontal orientation, width 1500, height 750, initially disabled
- Items StackPanel contains ItemsListView with GridView (columns: Id, PartitionKey)
- Adjusted OutputTextBox width to 1080 and positioned it to the right of ItemsListView