### PR TITLE
Clear ItemListViewCollection in LoadItemsAsync method

### DIFF
--- a/src/CosmosExplorer.UI/Common/SharedProperties.cs
+++ b/src/CosmosExplorer.UI/Common/SharedProperties.cs
@@ -72,6 +72,8 @@ namespace CosmosExplorer.UI.Common
 
         public static async Task LoadItemsAsync(string databaseName, string containerName)
         {
+            ItemListViewCollection.Clear();
+
             string query = "SELECT TOP 10 * FROM c";
             List<Tuple<string, string>> items = new List<Tuple<string, string>>();
 


### PR DESCRIPTION
Clear ItemListViewCollection in LoadItemsAsync method

Added ItemListViewCollection.Clear() to the LoadItemsAsync method in SharedProperties.cs within the CosmosExplorer.UI.Common namespace. This change ensures that the collection is emptied before loading new items, preventing the display of old or stale data.