### PR TITLE
Add BooleanToVisibilityConverter and LoaderIndicator

### DIFF
--- a/src/CosmosExplorer.UI/App.xaml
+++ b/src/CosmosExplorer.UI/App.xaml
@@ -4,6 +4,6 @@
              xmlns:local="clr-namespace:CosmosExplorer.UI"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-         
+        <local:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
     </Application.Resources>
 </Application>

--- a/src/CosmosExplorer.UI/Common/BooleanToVisibilityConverter.cs
+++ b/src/CosmosExplorer.UI/Common/BooleanToVisibilityConverter.cs
@@ -1,0 +1,27 @@
+﻿using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace CosmosExplorer.UI
+{
+    public class BooleanToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is bool boolValue)
+            {
+                return boolValue ? Visibility.Visible : Visibility.Collapsed;
+            }
+            return Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is Visibility visibility)
+            {
+                return visibility == Visibility.Visible;
+            }
+            return false;
+        }
+    }
+}

--- a/src/CosmosExplorer.UI/Common/CosmosExplorerHelper.cs
+++ b/src/CosmosExplorer.UI/Common/CosmosExplorerHelper.cs
@@ -3,10 +3,14 @@ using Microsoft.Azure.Cosmos;
 
 namespace CosmosExplorer.UI.Common
 {
-    public class CosmosExplorerHelper
+    public static class CosmosExplorerHelper
     {
-        // TODO: Make this property private and add a method to set it.
-        public static CosmosExplorerCore CosmosExplorerCore { get; set; }
+        private static CosmosExplorerCore CosmosExplorerCore { get; set; }
+
+        public static void Initialize(string connectionString)
+        {
+            CosmosExplorerCore = new CosmosExplorerCore(connectionString);
+        }
 
         public static async Task<List<string>> GetDatabases()
         {
@@ -59,6 +63,11 @@ namespace CosmosExplorer.UI.Common
         {
             Dictionary<string, List<ContainerInformation>> databases = await GetDatabasesInformationAsync().ConfigureAwait(true);
             SharedProperties.DatabaseCollection.LoadDatabases(databases);
+        }
+
+        public static async Task<dynamic> GetItemByIdAsync(string databaseName, string containerName, string itemId)
+        { 
+            return await CosmosExplorerCore.GetItemByIdAsync(databaseName, containerName, itemId).ConfigureAwait(true);
         }
 
         public static async Task LoadItemsAsync(string databaseName, string containerName)

--- a/src/CosmosExplorer.UI/Common/LoaderIndicator.cs
+++ b/src/CosmosExplorer.UI/Common/LoaderIndicator.cs
@@ -1,0 +1,32 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace CosmosExplorer.UI
+{
+    public class LoaderIndicator : INotifyPropertyChanged
+    {
+        private bool _isLoading;
+
+        public bool IsLoading
+        {
+            get => _isLoading;
+            set
+            {
+                _isLoading = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        public void SetLoaderIndicator(bool isLoading)
+        {
+            IsLoading = isLoading;
+        }
+    }
+}

--- a/src/CosmosExplorer.UI/Common/SharedProperties.cs
+++ b/src/CosmosExplorer.UI/Common/SharedProperties.cs
@@ -8,6 +8,8 @@
 
         public static Dictionary<string, string> ContainerPartitionKey { get; set; }
 
+        public static LoaderIndicator LoaderIndicator { get; set; }
+
         public static string SelectedDatabase { get; set; }
 
         public static string SelectedContainer { get; set; }

--- a/src/CosmosExplorer.UI/MainWindow.xaml
+++ b/src/CosmosExplorer.UI/MainWindow.xaml
@@ -71,5 +71,8 @@
 
             </StackPanel>
         </StackPanel>
+
+        <!-- Loader Indicator -->
+        <ProgressBar x:Name="LoaderIndicator" Width="200" Height="20" IsIndeterminate="True" Visibility="{Binding IsLoading, Converter={StaticResource BooleanToVisibilityConverter}}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
     </Grid>
 </Window>

--- a/src/CosmosExplorer.UI/MainWindow.xaml.cs
+++ b/src/CosmosExplorer.UI/MainWindow.xaml.cs
@@ -13,6 +13,9 @@ namespace CosmosExplorer.UI
         {
             InitializeComponent();
 
+            SharedProperties.LoaderIndicator = new LoaderIndicator();
+            DataContext = SharedProperties.LoaderIndicator;
+
             SharedProperties.DatabaseCollection = new DatabaseTreeCollection();
             DatabaseTreeView.ItemsSource = SharedProperties.DatabaseCollection;
 
@@ -58,7 +61,7 @@ namespace CosmosExplorer.UI
 
             DeleteButton.IsEnabled = true;
 
-            dynamic item = await CosmosExplorerHelper.CosmosExplorerCore.GetItemByIdAsync(SharedProperties.SelectedDatabase, SharedProperties.SelectedContainer, SharedProperties.SelectedItemId).ConfigureAwait(true);
+            dynamic item = await CosmosExplorerHelper.GetItemByIdAsync(SharedProperties.SelectedDatabase, SharedProperties.SelectedContainer, SharedProperties.SelectedItemId).ConfigureAwait(true);
 
             // Use Dispatcher to update the UI
             Dispatcher.Invoke(() =>

--- a/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml.cs
+++ b/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml.cs
@@ -1,5 +1,4 @@
-﻿using CosmosExplorer.Core;
-using CosmosExplorer.UI.Common;
+﻿using CosmosExplorer.UI.Common;
 using System.Windows;
 
 namespace CosmosExplorer.UI
@@ -17,7 +16,9 @@ namespace CosmosExplorer.UI
         private async void ConnectButton_Click(object sender, RoutedEventArgs e)
         {
             string connectionString = ConnectionStringTextBox.Text;
-            CosmosExplorerHelper.CosmosExplorerCore = new CosmosExplorerCore(connectionString);
+            CosmosExplorerHelper.Initialize(connectionString);
+
+            SharedProperties.LoaderIndicator.SetLoaderIndicator(true);
 
             // Get the MainWindow instance
             if (Application.Current.MainWindow is MainWindow mainWindow)
@@ -32,6 +33,8 @@ namespace CosmosExplorer.UI
 
             // Close the modal
             this.Close();
+
+            SharedProperties.LoaderIndicator.SetLoaderIndicator(false);
         }
     }
 }


### PR DESCRIPTION
Add BooleanToVisibilityConverter and LoaderIndicator

- Added BooleanToVisibilityConverter in App.xaml and implemented its logic in BooleanToVisibilityConverter.cs.
- Made CosmosExplorerHelper static, added Initialize and GetItemByIdAsync methods, and updated CosmosExplorerCore property.
- Introduced LoaderIndicator class for managing loading state with property change notifications.
- Updated SharedProperties to include LoaderIndicator property.
- Added ProgressBar in MainWindow.xaml, binding its visibility to IsLoading using BooleanToVisibilityConverter.
- Initialized LoaderIndicator in MainWindow.xaml.cs and updated GetItemByIdAsync call.
- Cleaned up ConnectResourceGroupModal.xaml.cs, updated connection logic, and added loader indicator state management.