### PR TITLE
Update UI elements and behavior in MainWindow and Modal

### DIFF
--- a/src/CosmosExplorer.UI/MainWindow.xaml
+++ b/src/CosmosExplorer.UI/MainWindow.xaml
@@ -3,7 +3,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:CosmosExplorer.UI"
         Title="Cosmos Explorer (Preview)" Height="1000" Width="1800"
-        Icon="/icons/Cosmos-DB.ico">
+        Icon="/icons/Cosmos-DB.ico"
+        WindowStartupLocation="CenterScreen">
     <Grid>
         <Menu VerticalAlignment="Top">
             <MenuItem Header="File">
@@ -42,17 +43,17 @@
             <StackPanel x:Name="CenterPanel" Orientation="Vertical" VerticalAlignment="Top" Width="1500" Height="860" Margin="20,0,0,0">
 
                 <StackPanel x:Name="ToolBar" Width="1500" Height="40" HorizontalAlignment="Left" Orientation="Horizontal" Margin="0,0,0,10">
-                    <Button x:Name="NewItemButton" Content="New Item" Width="100" Click="NewItem_Click" Height="30" FontSize="18" IsEnabled="False" Margin="0,0,10,0"/>
-                    <Button x:Name="SaveButton" Content="Save" Width="100" Click="Save_Click" Height="30" FontSize="18" IsEnabled="False" Margin="0,0,10,0" Visibility="Collapsed"/>
-                    <Button x:Name="UpdateButton" Content="Update" Width="100" Click="Update_Click" Height="30" FontSize="18" IsEnabled="False" Margin="0,0,10,0"/>
-                    <Button x:Name="DiscardButton" Content="Discard" Width="100" Click="Discard_Click" Height="30" FontSize="18" IsEnabled="False" Margin="0,0,10,0" Visibility="Collapsed"/>
-                    <Button x:Name="DeleteButton" Content="Delete" Width="100" Click="Delete_Click" Height="30" FontSize="18" IsEnabled="False" Margin="0,0,10,0"/>
+                    <Button x:Name="NewItemButton" Content="New Item" Width="100" Click="NewItem_Click" Height="30" FontSize="16" IsEnabled="False" Margin="0,0,10,0"/>
+                    <Button x:Name="SaveButton" Content="Save" Width="100" Click="Save_Click" Height="30" FontSize="16" IsEnabled="False" Margin="0,0,10,0" Visibility="Collapsed"/>
+                    <Button x:Name="UpdateButton" Content="Update" Width="100" Click="Update_Click" Height="30" FontSize="16" IsEnabled="False" Margin="0,0,10,0"/>
+                    <Button x:Name="DiscardButton" Content="Discard" Width="100" Click="Discard_Click" Height="30" FontSize="16" IsEnabled="False" Margin="0,0,10,0" Visibility="Collapsed"/>
+                    <Button x:Name="DeleteButton" Content="Delete" Width="100" Click="Delete_Click" Height="30" FontSize="16" IsEnabled="False" Margin="0,0,10,0"/>
                 </StackPanel>
 
                 <StackPanel x:Name="FilterPanel" Orientation="Horizontal" VerticalAlignment="Top" Width="1500" IsEnabled="False">
-                    <TextBox Width="160" Height="30" FontSize="18" Text=" SELECT * FROM c " IsReadOnly="True"/>
-                    <TextBox x:Name="FilterTextBox" Width="1240" Height="30" FontSize="18"/>
-                    <Button Content="Apply filter" Width="100" Click="FilterButton_Click" Height="30" FontSize="18"/>
+                    <TextBox Width="160" Height="30" FontSize="16" Text=" SELECT * FROM c " IsReadOnly="True"/>
+                    <TextBox x:Name="FilterTextBox" Width="1240" Height="30" FontSize="16"/>
+                    <Button Content="Apply filter" Width="100" Click="FilterButton_Click" Height="30" FontSize="16"/>
                 </StackPanel>
 
                 <StackPanel x:Name="Items" Orientation="Horizontal" Width="1500" Height="780" IsEnabled="False" Margin="0,10,0,0">
@@ -71,7 +72,5 @@
 
             </StackPanel>
         </StackPanel>
-
-        <ProgressBar x:Name="LoaderIndicator" Width="200" Height="20" IsIndeterminate="True" Visibility="{Binding IsLoading, Converter={StaticResource BooleanToVisibilityConverter}}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
     </Grid>
 </Window>

--- a/src/CosmosExplorer.UI/MainWindow.xaml.cs
+++ b/src/CosmosExplorer.UI/MainWindow.xaml.cs
@@ -31,6 +31,10 @@ namespace CosmosExplorer.UI
 
             FilterPanel.IsEnabled = false;
 
+            Items.IsEnabled = false;
+            ItemListView.IsEnabled = false;
+            ItemDescriptionTextBox.IsEnabled = false;
+
             ItemDescriptionTextBox.Text = string.Empty;
 
             SharedProperties.ItemListViewCollection.Clear();
@@ -45,6 +49,10 @@ namespace CosmosExplorer.UI
             NewItemButton.IsEnabled = true;
 
             FilterPanel.IsEnabled = true;
+
+            ItemListView.IsEnabled = true;
+            Items.IsEnabled = true;
+            ItemDescriptionTextBox.IsEnabled = true;
 
             ItemDescriptionTextBox.Text = string.Empty;
         }

--- a/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml
+++ b/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml
@@ -1,11 +1,15 @@
 ﻿<Window x:Class="CosmosExplorer.UI.ConnectResourceGroupModal"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="ConnectResourceGroupModal" Height="220" Width="900">
+        Title="Enter the connection string" Width="900" Height="260">
     <Grid>
-        <StackPanel Height="200" Width="800" Orientation="Vertical">
+        <StackPanel x:Name="ConnectionStringPanel" Height="220" Width="800" Orientation="Vertical">
+            <Label Content="Account endpoint" FontSize="16" HorizontalAlignment="Left"/>
             <TextBox x:Name="ConnectionStringTextBox" Height="100" Width="780" Margin="10" Foreground="Gray" HorizontalAlignment="Left" FontSize="16" AcceptsReturn="True" TextWrapping="Wrap"/>
-            <Button Content="Connect" Width="100" Margin="10" Click="ConnectButton_Click" FontSize="18" HorizontalAlignment="Right"/>
+            <Button Content="Connect" Width="100" Margin="10" Click="ConnectButton_Click" FontSize="16" HorizontalAlignment="Right"/>
+        </StackPanel>
+        <StackPanel x:Name="Loader" Visibility="Hidden" HorizontalAlignment="Center" VerticalAlignment="Center">
+            <ProgressBar x:Name="LoaderIndicator" Width="600" Height="20" IsIndeterminate="True" Visibility="{Binding IsLoading, Converter={StaticResource BooleanToVisibilityConverter}}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml.cs
+++ b/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml.cs
@@ -19,13 +19,13 @@ namespace CosmosExplorer.UI
             CosmosExplorerHelper.Initialize(connectionString);
 
             SharedProperties.LoaderIndicator.SetLoaderIndicator(true);
+            ConnectionStringPanel.Visibility = Visibility.Collapsed;
+            Loader.Visibility = Visibility.Visible;
 
             // Get the MainWindow instance
             if (Application.Current.MainWindow is MainWindow mainWindow)
             {
                 mainWindow.LeftPanel.IsEnabled = true;
-                mainWindow.ItemDescriptionTextBox.IsEnabled = true;
-                mainWindow.Items.IsEnabled = true; // TODO: Remove this line
             }
 
             await CosmosExplorerHelper.LoadDatabasesAsync().ConfigureAwait(true);


### PR DESCRIPTION
Update UI elements and behavior in MainWindow and Modal

- Center MainWindow on screen and adjust font sizes of buttons and text boxes
- Remove LoaderIndicator ProgressBar from MainWindow.xaml
- Disable and clear UI elements in MainWindow.xaml.cs under certain conditions
- Update ConnectResourceGroupModal title and increase window height
- Add "Account endpoint" label and reduce Connect button font size in ConnectResourceGroupModal
- Add Loader StackPanel with ProgressBar to ConnectResourceGroupModal
- Adjust visibility of ConnectionStringPanel and Loader during connection process
- Remove enabling of ItemDescriptionTextBox and Items in ConnectResourceGroupModal.xaml.cs