### PR TITLE
Add new features and reset properties on selection change

### DIFF
--- a/docs/next features.md
+++ b/docs/next features.md
@@ -1,5 +1,8 @@
 # Next features:
 
+* Implement discard on edit item
+* Show confirmation modal before to delete
+
 * Create container
 * Delete container
 * Create database

--- a/src/CosmosExplorer.UI/MainWindow.xaml.cs
+++ b/src/CosmosExplorer.UI/MainWindow.xaml.cs
@@ -25,6 +25,12 @@ namespace CosmosExplorer.UI
 
         private async void DatabaseTreeView_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
         {
+            SharedProperties.SelectedDatabase = string.Empty;
+            SharedProperties.SelectedContainer = string.Empty;
+            SharedProperties.SelectedItemId = string.Empty;
+            SharedProperties.SelectedItemPartitionKey = string.Empty;
+            SharedProperties.SelectedItemJson = string.Empty;
+
             NewItemButton.IsEnabled = false;
             DeleteButton.IsEnabled = false;
             UpdateButton.IsEnabled = false;


### PR DESCRIPTION
Add new features and reset properties on selection change

Updated `features.md` to include new functionalities:
- Implement discard option on edit
- Show confirmation modal before deletion
- Create and delete containers and databases

In `MainWindow.xaml.cs`, reset `SharedProperties` fields to
empty strings when the selected item in `DatabaseTreeView`
changes, and disable relevant buttons and filter panel.