### PR TITLE
Refactor item editing and update feature set

### DIFF
--- a/docs/next features.md
+++ b/docs/next features.md
@@ -1,7 +1,7 @@
 # Next features:
 
-* Implement discard on edit item
 * Show confirmation modal before to delete
+* Adjust sizes
 
 * Create container
 * Delete container

--- a/src/CosmosExplorer.UI/Common/CosmosExplorerHelper.cs
+++ b/src/CosmosExplorer.UI/Common/CosmosExplorerHelper.cs
@@ -66,7 +66,7 @@ namespace CosmosExplorer.UI.Common
         }
 
         public static async Task<dynamic> GetItemByIdAsync(string databaseName, string containerName, string itemId)
-        { 
+        {
             return await CosmosExplorerCore.GetItemByIdAsync(databaseName, containerName, itemId).ConfigureAwait(true);
         }
 
@@ -135,16 +135,16 @@ namespace CosmosExplorer.UI.Common
         }
 
         public static async Task UpdateItemAsync(string itemId, string partitionKey, dynamic item)
-        { 
+        {
             await CosmosExplorerCore.UpdateItemAsync(SharedProperties.SelectedDatabase, SharedProperties.SelectedContainer, itemId, partitionKey, item).ConfigureAwait(true);
         }
 
-        public static bool IsContentEqual(string original, string current)
+        public static void SetEditMode(string original, string current)
         {
             string originalHash = GenerateHash(original);
             string currentHash = GenerateHash(current);
 
-            return originalHash.Equals(currentHash, StringComparison.Ordinal);
+            SharedProperties.IsEditMode = !originalHash.Equals(currentHash, StringComparison.Ordinal);
         }
 
         private static string GenerateHash(string input)

--- a/src/CosmosExplorer.UI/Common/SharedProperties.cs
+++ b/src/CosmosExplorer.UI/Common/SharedProperties.cs
@@ -10,6 +10,10 @@
 
         public static LoaderIndicator LoaderIndicator { get; set; }
 
+        public static bool IsEditMode { get; set; } = false;
+
+        public static bool IsCreatingItem { get; set; } = false;
+
         public static string SelectedDatabase { get; set; }
 
         public static string SelectedContainer { get; set; }


### PR DESCRIPTION
Refactor item editing and update feature set

- Updated `features.md` to remove "Implement discard on edit item" and add new features: "Adjust sizes," "Create container," "Delete container," "Create database," and "Delete database."
- Modified `CosmosExplorerHelper.cs` to improve method readability and replace `IsContentEqual` with `SetEditMode` for managing edit state.
- Added `IsEditMode` and `IsCreatingItem` properties in `SharedProperties.cs`.
- Enhanced button logic in `MainWindow.xaml.cs` to manage visibility and state based on item creation and editing.
- Updated event handlers to reflect changes in edit state and button enabling/disabling logic.