### PR TITLE
Add confirmation modal for item deletion

### DIFF
--- a/src/CosmosExplorer.UI/MainWindow.xaml.cs
+++ b/src/CosmosExplorer.UI/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using CosmosExplorer.UI.Common;
+using CosmosExplorer.UI.Modal;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -236,6 +237,15 @@ namespace CosmosExplorer.UI
 
         private async void Delete_Click(object sender, RoutedEventArgs e)
         {
+            // Show the confirmation modal.
+            ConfirmationModal confirmationModal = new ConfirmationModal();
+            bool? confirmationResult = confirmationModal.ShowDialog();
+
+            if (confirmationResult is false)
+            {
+                return;
+            }
+
             await CosmosExplorerHelper.DeleteItemAsync(SharedProperties.SelectedItemId, SharedProperties.SelectedItemPartitionKey).ConfigureAwait(true);
 
             SharedProperties.ItemListViewCollection.RemoveAt(ItemListView.SelectedIndex);

--- a/src/CosmosExplorer.UI/Modal/ConfirmationModal.xaml
+++ b/src/CosmosExplorer.UI/Modal/ConfirmationModal.xaml
@@ -1,0 +1,19 @@
+﻿<Window x:Class="CosmosExplorer.UI.Modal.ConfirmationModal"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:CosmosExplorer.UI.Modal"
+        mc:Ignorable="d"
+        Title="Confirm delete" Height="150" Width="400"
+        WindowStartupLocation="CenterScreen">
+    <Grid>
+        <TextBlock Text="Are you sure you want to delete the selected item?" 
+                   HorizontalAlignment="Center" VerticalAlignment="Center" 
+                   Margin="0,0,0,40" FontSize="16"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="0,0,0,20">
+            <Button Content="Delete" Width="100" Margin="10" Click="Delete_Click"/>
+            <Button Content="Cancel" Width="100" Margin="10" Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/CosmosExplorer.UI/Modal/ConfirmationModal.xaml.cs
+++ b/src/CosmosExplorer.UI/Modal/ConfirmationModal.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System.Windows;
+
+namespace CosmosExplorer.UI.Modal
+{
+    public partial class ConfirmationModal : Window
+    {
+        public ConfirmationModal()
+        {
+            InitializeComponent();
+        }
+
+        private void Delete_Click(object sender, RoutedEventArgs e)
+        {
+            this.DialogResult = true;
+            this.Close();
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            this.DialogResult = false;
+            this.Close();
+        }
+    }
+}


### PR DESCRIPTION
Add confirmation modal for item deletion

This update introduces a confirmation modal in the Cosmos Explorer application. When the delete action is triggered, the modal prompts the user for confirmation. If confirmed, the selected item is removed from the list. The `ConfirmationModal` class is implemented in `ConfirmationModal.xaml` and `ConfirmationModal.xaml.cs`, providing the necessary UI and functionality for confirming or canceling the deletion.