### PR TITLE
Enhance UI state management and window properties

### DIFF
--- a/src/CosmosExplorer.UI/MainWindow.xaml.cs
+++ b/src/CosmosExplorer.UI/MainWindow.xaml.cs
@@ -157,6 +157,8 @@ namespace CosmosExplorer.UI
 
             SharedProperties.IsCreatingItem = true;
 
+            DatabaseTreeView.IsEnabled = false;
+
             // Important this should be the last line!!!
             ItemDescriptionTextBox.Text = string.Empty;
         }
@@ -175,6 +177,10 @@ namespace CosmosExplorer.UI
 
             if (SharedProperties.IsEditMode)
             {
+                DatabaseTreeView.IsEnabled = false;
+                ItemListView.IsEnabled = false;
+                FilterPanel.IsEnabled = false;
+
                 UpdateButton.IsEnabled = true;
 
                 DiscardButton.IsEnabled = true;
@@ -196,6 +202,10 @@ namespace CosmosExplorer.UI
             UpdateButton.IsEnabled = false;
 
             SharedProperties.IsEditMode = false;
+
+            DatabaseTreeView.IsEnabled = true;
+            ItemListView.IsEnabled = true;
+            FilterPanel.IsEnabled = true;
         }
 
         private void Discard_Click(object sender, RoutedEventArgs e)
@@ -216,6 +226,7 @@ namespace CosmosExplorer.UI
 
             FilterPanel.IsEnabled = true;
 
+            DatabaseTreeView.IsEnabled = true;
             ItemListView.IsEnabled = true;
 
             if (SharedProperties.IsEditMode)
@@ -224,6 +235,8 @@ namespace CosmosExplorer.UI
                 DeleteButton.IsEnabled = true;
 
                 SharedProperties.IsEditMode = false;
+
+                FilterPanel.IsEnabled = true;
             }
             
             if(SharedProperties.IsCreatingItem)
@@ -303,6 +316,8 @@ namespace CosmosExplorer.UI
             ItemListView.IsEnabled = true;
 
             SharedProperties.IsCreatingItem = false;
+
+            DatabaseTreeView.IsEnabled = true;
         }
     }
 }

--- a/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml
+++ b/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="CosmosExplorer.UI.ConnectResourceGroupModal"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Enter the connection string" Width="900" Height="260">
+        Title="Enter the connection string" WindowStartupLocation="CenterScreen" Width="900" Height="260" ResizeMode="NoResize">
     <Grid>
         <StackPanel x:Name="ConnectionStringPanel" Height="220" Width="800" Orientation="Vertical">
             <Label Content="Account endpoint" FontSize="16" HorizontalAlignment="Left"/>

--- a/src/CosmosExplorer.UI/Menu/Help/AboutWindow.xaml
+++ b/src/CosmosExplorer.UI/Menu/Help/AboutWindow.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="CosmosExplorer.UI.AboutWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="About Cosmos Explorer" Height="300" Width="600">
+        Title="About Cosmos Explorer" Height="300" Width="600" WindowStartupLocation="CenterScreen"  ResizeMode="NoResize">
     <Grid>
         <StackPanel Margin="10" HorizontalAlignment="Center" VerticalAlignment="Center">
             <TextBlock Text="Cosmos Explorer" FontSize="24" FontWeight="Bold" Margin="0,0,0,5"/>

--- a/src/CosmosExplorer.UI/Modal/ConfirmationModal.xaml
+++ b/src/CosmosExplorer.UI/Modal/ConfirmationModal.xaml
@@ -5,8 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:CosmosExplorer.UI.Modal"
         mc:Ignorable="d"
-        Title="Confirm delete" Height="150" Width="400"
-        WindowStartupLocation="CenterScreen">
+        Title="Confirm delete" Height="150" Width="700"
+        WindowStartupLocation="CenterScreen" ResizeMode="NoResize">
     <Grid>
         <TextBlock Text="Are you sure you want to delete the selected item?" 
                    HorizontalAlignment="Center" VerticalAlignment="Center" 


### PR DESCRIPTION
Enhance UI state management and window properties

Updated `MainWindow.xaml.cs` to enable/disable UI elements
based on item creation and editing states, improving user
experience. Added `WindowStartupLocation="CenterScreen"`
and `ResizeMode="NoResize"` to various XAML files to ensure
consistent window behavior and layout.