### PR TITLE
Update UI layout and component dimensions

### DIFF
--- a/src/CosmosExplorer.UI/MainWindow.xaml
+++ b/src/CosmosExplorer.UI/MainWindow.xaml
@@ -1,7 +1,8 @@
-﻿<Window x:Class="CosmosExplorer.UI.MainWindow"
+﻿<Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:CosmosExplorer.UI"
+        xmlns:av="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="av" x:Class="CosmosExplorer.UI.MainWindow"
         Title="Cosmos Explorer (Preview)" Height="1000" Width="1800"
         Icon="/Icons/Cosmos explorer.ico"
         WindowStartupLocation="CenterScreen">
@@ -19,8 +20,8 @@
 
         <StackPanel Orientation="Horizontal" Margin="30,45,30,45">
 
-            <StackPanel x:Name="LeftPanel" IsEnabled="False" Width="200" Height="860" HorizontalAlignment="Left" VerticalAlignment="Top">
-                <TreeView x:Name="DatabaseTreeView" Width="200" Height="860" SelectedItemChanged="DatabaseTreeView_SelectedItemChanged">
+            <StackPanel x:Name="LeftPanel" IsEnabled="False" Width="250" Height="860" HorizontalAlignment="Left" VerticalAlignment="Top">
+                <TreeView x:Name="DatabaseTreeView" Width="250" Height="860" SelectedItemChanged="DatabaseTreeView_SelectedItemChanged">
                     <TreeView.ItemTemplate>
                         <HierarchicalDataTemplate DataType="{x:Type local:DatabaseTreeSource}" ItemsSource="{Binding Containers}">
                             <StackPanel Orientation="Horizontal" Margin="0,0,8,8">
@@ -40,9 +41,9 @@
                 </TreeView>
             </StackPanel>
 
-            <StackPanel x:Name="CenterPanel" Orientation="Vertical" VerticalAlignment="Top" Width="1500" Height="860" Margin="20,0,0,0">
+            <StackPanel x:Name="CenterPanel" Orientation="Vertical" VerticalAlignment="Top" Width="1450" Height="860" Margin="20,0,0,0">
 
-                <StackPanel x:Name="ToolBar" Width="1500" Height="40" HorizontalAlignment="Left" Orientation="Horizontal" Margin="0,0,0,10">
+                <StackPanel x:Name="ToolBar" Width="1450" Height="40" HorizontalAlignment="Left" Orientation="Horizontal" Margin="0,0,0,10">
                     <Button x:Name="NewItemButton" Content="New Item" Width="100" Click="NewItem_Click" Height="30" FontSize="14" IsEnabled="False" Margin="0,0,10,0"/>
                     <Button x:Name="SaveButton" Content="Save" Width="100" Click="Save_Click" Height="30" FontSize="14" IsEnabled="False" Margin="0,0,10,0" Visibility="Collapsed"/>
                     <Button x:Name="UpdateButton" Content="Update" Width="100" Click="Update_Click" Height="30" FontSize="14" IsEnabled="False" Margin="0,0,10,0"/>
@@ -50,24 +51,24 @@
                     <Button x:Name="DeleteButton" Content="Delete" Width="100" Click="Delete_Click" Height="30" FontSize="14" IsEnabled="False" Margin="0,0,10,0"/>
                 </StackPanel>
 
-                <StackPanel x:Name="FilterPanel" Orientation="Horizontal" VerticalAlignment="Top" Width="1500" IsEnabled="False">
+                <StackPanel x:Name="FilterPanel" Orientation="Horizontal" VerticalAlignment="Top" Width="1450" IsEnabled="False">
                     <TextBox Width="140" Height="30" FontSize="14" Text=" SELECT * FROM c " IsReadOnly="True" VerticalAlignment="Center"/>
-                    <TextBox x:Name="FilterTextBox" Width="1260" Height="30" FontSize="14"/>
+                    <TextBox x:Name="FilterTextBox" Width="1210" Height="30" FontSize="14"/>
                     <Button Content="Apply filter" Width="100" Click="FilterButton_Click" Height="30" FontSize="14"/>
                 </StackPanel>
 
-                <StackPanel x:Name="Items" Orientation="Horizontal" Width="1500" Height="780" IsEnabled="False" Margin="0,10,0,0">
+                <StackPanel x:Name="Items" Orientation="Horizontal" Width="1450" Height="780" IsEnabled="False" Margin="0,10,0,0">
 
-                    <ListView x:Name="ItemListView" Width="400" Height="760" SelectionChanged="ItemsListView_SelectionChanged">
+                    <ListView x:Name="ItemListView" Width="530" Height="760" SelectionChanged="ItemsListView_SelectionChanged" av:ItemsSource="{av:SampleData ItemCount=5}">
                         <ListView.View>
                             <GridView>
-                                <GridViewColumn Header="Id" DisplayMemberBinding="{Binding Id}" Width="190"/>
-                                <GridViewColumn Header="PartitionKey" DisplayMemberBinding="{Binding PartitionKey}" Width="190"/>
+                                <GridViewColumn Header="Id" DisplayMemberBinding="{Binding Id}" Width="260"/>
+                                <GridViewColumn Header="PartitionKey" DisplayMemberBinding="{Binding PartitionKey}" Width="260"/>
                             </GridView>
                         </ListView.View>
                     </ListView>
 
-                    <TextBox x:Name="ItemDescriptionTextBox" Width="1080" Height="760" Margin="20,0,0,0" TextWrapping="Wrap" FontSize="14" IsEnabled="False" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" TextChanged="ItemDescriptionTextBox_TextChanged"/>
+                    <TextBox x:Name="ItemDescriptionTextBox" Width="910" Height="760" Margin="10,0,0,0" TextWrapping="Wrap" FontSize="14" IsEnabled="False" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" TextChanged="ItemDescriptionTextBox_TextChanged"/>
                 </StackPanel>
 
             </StackPanel>


### PR DESCRIPTION
Update UI layout and component dimensions

- Increased the width of `LeftPanel` and `DatabaseTreeView` to 250.
- Decreased the width of `CenterPanel`, `ToolBar`, `FilterPanel`, and `Items` to 1450.
- Reduced the width of `FilterTextBox` to 1210.
- Increased the width of `ItemListView` to 530 and adjusted `GridViewColumn` widths for "Id" and "PartitionKey" to 260.
- Decreased the width of `ItemDescriptionTextBox` to 910 and adjusted its margin.
- Added `av:ItemsSource` attribute to `ItemListView` for sample data.