### PR TITLE
Improve partition key handling and UI clarity

### DIFF
--- a/src/CosmosExplorer.UI/Common/CosmosExplorerHelper.cs
+++ b/src/CosmosExplorer.UI/Common/CosmosExplorerHelper.cs
@@ -121,14 +121,21 @@ namespace CosmosExplorer.UI.Common
 
                 FeedIterator<dynamic> iterator = CosmosExplorerCore.GetQueryIterator(SharedProperties.SelectedDatabase, SharedProperties.SelectedContainer, query);
 
+                string partitionKeyName = SharedProperties.ContainerPartitionKey[SharedProperties.SelectedContainer].TrimStart('/');
+
                 while (iterator.HasMoreResults)
                 {
                     FeedResponse<dynamic> response = await iterator.ReadNextAsync().ConfigureAwait(true);
                     foreach (var item in response)
                     {
-                        string partitionKey = SharedProperties.ContainerPartitionKey[SharedProperties.SelectedContainer].TrimStart('/');
-                        items.Add(new Tuple<string, string>(item["id"].ToString(), item[partitionKey].ToString()));
+                        items.Add(new Tuple<string, string>(item["id"].ToString(), item[partitionKeyName].ToString()));
                     }
+                }
+
+                // Get the MainWindow instance
+                if (Application.Current.MainWindow is MainWindow mainWindow)
+                {
+                    mainWindow.PartitionKeyColumn.Header = partitionKeyName;
                 }
 
                 SharedProperties.ItemListViewCollection.LoadItems(items);

--- a/src/CosmosExplorer.UI/MainWindow.xaml
+++ b/src/CosmosExplorer.UI/MainWindow.xaml
@@ -63,7 +63,7 @@
                         <ListView.View>
                             <GridView>
                                 <GridViewColumn Header="Id" DisplayMemberBinding="{Binding Id}" Width="260"/>
-                                <GridViewColumn Header="PartitionKey" DisplayMemberBinding="{Binding PartitionKey}" Width="260"/>
+                                <GridViewColumn x:Name="PartitionKeyColumn" Header="PartitionKey" DisplayMemberBinding="{Binding PartitionKey}" Width="260"/>
                             </GridView>
                         </ListView.View>
                     </ListView>


### PR DESCRIPTION
Improve partition key handling and UI clarity

Updated `CosmosExplorerHelper.cs` to introduce a new variable `partitionKeyName` for better partition key management and to set the `PartitionKeyColumn` header in the `MainWindow`. Modified `MainWindow.xaml` to name the `GridViewColumn` for the partition key, enhancing code maintainability and clarity.