### PR TITLE
Refactor menu structure and connection handling

### DIFF
--- a/src/CosmosExplorer.UI/MainWindow.xaml
+++ b/src/CosmosExplorer.UI/MainWindow.xaml
@@ -8,9 +8,9 @@
         WindowStartupLocation="CenterScreen">
     <Grid>
         <Menu VerticalAlignment="Top">
-            <MenuItem Header="File" Click="MenuItem_Click">
+            <MenuItem Header="File">
                 <MenuItem Header="New connection" Click="OpenConnectionModal_Click"/>
-                <MenuItem Name="SavedConnectionMenuItem" Header="Saved connections" IsEnabled="False"/>
+                <MenuItem Header="Saved connections" Name="SavedConnectionMenuItem" IsEnabled="False"/>
                 <Separator/>
                 <MenuItem Header="Exit" Click="CloseApplication_Click"/>
             </MenuItem>

--- a/src/CosmosExplorer.UI/MainWindow.xaml.cs
+++ b/src/CosmosExplorer.UI/MainWindow.xaml.cs
@@ -29,9 +29,10 @@ namespace CosmosExplorer.UI
             ItemListView.ItemsSource = SharedProperties.ItemListViewCollection;
 
             LoadSavedConnectionsFromFile();
+            PopulateSavedConnectionsMenu();
         }
 
-        private void LoadSavedConnectionsFromFile()
+        private static void LoadSavedConnectionsFromFile()
         {
             string exeDirectory = AppContext.BaseDirectory;
             string filePath = Path.Combine(exeDirectory, "savedConnections.json");
@@ -96,12 +97,6 @@ namespace CosmosExplorer.UI
             MainPanel.Visibility = Visibility.Visible;
             SharedProperties.LoaderIndicator.SetLoaderIndicator(false);
             LeftPanel.IsEnabled = true;
-
-        }
-
-        private void MenuItem_Click(object sender, RoutedEventArgs e)
-        {
-            PopulateSavedConnectionsMenu();
         }
 
         private void OpenConnectionModal_Click(object sender, RoutedEventArgs e)
@@ -217,7 +212,6 @@ namespace CosmosExplorer.UI
 
         private async void FilterButton_Click(object sender, RoutedEventArgs e)
         {
-            // TODO: Check this line. filter with a row selected.
             DisplayJson(string.Empty);
 
             bool result = await CosmosExplorerHelper.SearchByQueryAsync(FilterTextBox.Text).ConfigureAwait(true);


### PR DESCRIPTION
Refactor menu structure and connection handling

- Updated the "File" menu in `MainWindow.xaml` to include "Saved connections" as a child item and removed the `MenuItem_Click` event handler.
- Changed `LoadSavedConnectionsFromFile` to a static method in `MainWindow.xaml.cs` and retained the `OpenConnectionModal_Click` method.
- Enhanced `SaveButton_Click` in `ConnectResourceGroupModal.xaml.cs` to add new menu items for saved connections after saving.
- Introduced `ConnectionMenuItem_Click` to handle saved connection selections and manage UI visibility during database loading.