### PR TITLE
Add encryption settings and refactor SharedProperties

### DIFF
--- a/src/CosmosExplorer.UI/App.config
+++ b/src/CosmosExplorer.UI/App.config
@@ -1,0 +1,6 @@
+﻿<configuration>
+	<appSettings>
+		<add key="EncryptionKey" value="bWluZGVyLXNlY3JldC1rZXktZm9yLWFlcy1lbmNyeXB0aW9u" />
+		<add key="EncryptionIV" value="bWluZGVyLXNlY3JldC1pdi1mb3ItYWVz" />
+	</appSettings>
+</configuration>

--- a/src/CosmosExplorer.UI/Common/SharedProperties.cs
+++ b/src/CosmosExplorer.UI/Common/SharedProperties.cs
@@ -1,7 +1,15 @@
-﻿namespace CosmosExplorer.UI.Common
+﻿using System.Configuration;
+
+namespace CosmosExplorer.UI.Common
 {
     public static class SharedProperties
     {
+        static SharedProperties()
+        {
+            Key = Convert.FromBase64String(ConfigurationManager.AppSettings["EncryptionKey"]);
+            IV = Convert.FromBase64String(ConfigurationManager.AppSettings["EncryptionIV"]);
+        }
+
         public static Dictionary<string, string> SavedConnections { get; set; } = new Dictionary<string, string>();
 
         public static DatabaseTreeCollection DatabaseCollection { get; set; }
@@ -26,9 +34,8 @@
 
         public static string? SelectedItemJson { get; set; } = null;
 
-        // TODO: Read from configuration.
-        public static byte[] Key = Convert.FromBase64String("bWluZGVyLXNlY3JldC1rZXktZm9yLWFlcy1lbmNyeXB0aW9u");
+        public static byte[] Key { get; private set; }
 
-        public static byte[] IV = Convert.FromBase64String("bWluZGVyLXNlY3JldC1pdi1mb3ItYWVz");
+        public static byte[] IV { get; private set; }
     }
 }

--- a/src/CosmosExplorer.UI/CosmosExplorer.UI.csproj
+++ b/src/CosmosExplorer.UI/CosmosExplorer.UI.csproj
@@ -9,6 +9,18 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="App.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="App.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\CosmosExplorer\CosmosExplorer.Core.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Add encryption settings and refactor SharedProperties

- Introduced `App.config` for `EncryptionKey` and `EncryptionIV`.
- Updated `SharedProperties.cs` to initialize keys from `App.config`.
- Changed `Key` and `IV` from public fields to private properties.
- Modified project file to embed `App.config` and added `Microsoft.Extensions.Configuration` package.