### PR TITLE
Remove App.config references from project file

### DIFF
--- a/src/CosmosExplorer.UI/CosmosExplorer.UI.csproj
+++ b/src/CosmosExplorer.UI/CosmosExplorer.UI.csproj
@@ -9,14 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="App.config" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Include="App.config" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Remove App.config references from project file

Eliminated `<ItemGroup>` entries for `App.config`,
removing its inclusion as both a non-embedded and
embedded resource. Retained the existing
`Microsoft.Extensions.Configuration` package reference
at version 9.0.1.