### PR TITLE
Add UserSettingsFile configuration and refactor paths

### DIFF
--- a/src/CosmosExplorer.UI/App.config
+++ b/src/CosmosExplorer.UI/App.config
@@ -2,5 +2,6 @@
 	<appSettings>
 		<add key="EncryptionKey" value="" />
 		<add key="EncryptionIV" value="" />
+		<add key="UserSettingsFile" value="UserSettings.config" />
 	</appSettings>
 </configuration>

--- a/src/CosmosExplorer.UI/Common/SharedProperties.cs
+++ b/src/CosmosExplorer.UI/Common/SharedProperties.cs
@@ -8,6 +8,8 @@ namespace CosmosExplorer.UI.Common
         {
             Key = Convert.FromBase64String(ConfigurationManager.AppSettings["EncryptionKey"]);
             IV = Convert.FromBase64String(ConfigurationManager.AppSettings["EncryptionIV"]);
+
+            UserSettingsFileName = ConfigurationManager.AppSettings["UserSettingsFile"] ?? "UserSettings.config";
         }
 
         public static Dictionary<string, string> SavedConnections { get; set; } = new Dictionary<string, string>();
@@ -37,5 +39,7 @@ namespace CosmosExplorer.UI.Common
         public static byte[] Key { get; private set; }
 
         public static byte[] IV { get; private set; }
+
+        public static string UserSettingsFileName { get; private set; }
     }
 }

--- a/src/CosmosExplorer.UI/MainWindow.xaml.cs
+++ b/src/CosmosExplorer.UI/MainWindow.xaml.cs
@@ -36,7 +36,7 @@ namespace CosmosExplorer.UI
         private static void LoadSavedConnectionsFromFile()
         {
             string exeDirectory = AppContext.BaseDirectory;
-            string filePath = Path.Combine(exeDirectory, "savedConnections.json");
+            string filePath = Path.Combine(exeDirectory, SharedProperties.UserSettingsFileName);
 
             if (!File.Exists(filePath))
             {

--- a/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml.cs
+++ b/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml.cs
@@ -86,7 +86,7 @@ namespace CosmosExplorer.UI
                 SharedProperties.SavedConnections.Add(connectionStringName, connectionString);
 
                 string exeDirectory = AppContext.BaseDirectory;
-                string filePath = Path.Combine(exeDirectory, "savedConnections.json");
+                string filePath = Path.Combine(exeDirectory, SharedProperties.UserSettingsFileName);
 
                 string savedConnections = JsonSerializer.Serialize(SharedProperties.SavedConnections, new JsonSerializerOptions { WriteIndented = true });
 


### PR DESCRIPTION
Add UserSettingsFile configuration and refactor paths

Updated App.config to include UserSettingsFile setting.
Modified SharedProperties to read this setting and added
UserSettingsFileName property. Refactored file paths in
MainWindow.xaml.cs and ConnectResourceGroupModal.xaml.cs
to use the new property instead of hardcoded values.