### PR TITLE
Update user settings file path and handling

### DIFF
--- a/src/CosmosExplorer.UI/MainWindow.xaml.cs
+++ b/src/CosmosExplorer.UI/MainWindow.xaml.cs
@@ -35,18 +35,25 @@ namespace CosmosExplorer.UI
 
         private static void LoadSavedConnectionsFromFile()
         {
-            string exeDirectory = AppContext.BaseDirectory;
-            string filePath = Path.Combine(exeDirectory, SharedProperties.UserSettingsFileName);
+            string userSettingsPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CosmosExplorer", SharedProperties.UserSettingsFileName);
 
-            if (!File.Exists(filePath))
+            // Ensure the directory exists.
+            string directoryPath = Path.GetDirectoryName(userSettingsPath);
+            if (!Directory.Exists(directoryPath))
             {
-                File.WriteAllText(filePath, "{}");
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            // Ensure the file exists.
+            if (!File.Exists(userSettingsPath))
+            {
+                File.WriteAllText(userSettingsPath, "");
                 return;
             }
 
             try
             {
-                string encryptedContent = File.ReadAllText(filePath);
+                string encryptedContent = File.ReadAllText(userSettingsPath);
                 string decryptedContent = Utils.Decrypt(encryptedContent, SharedProperties.Key, SharedProperties.IV);
 
                 Dictionary<string, string> savedConnections = JsonConvert.DeserializeObject<Dictionary<string, string>>(decryptedContent);

--- a/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml.cs
+++ b/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml.cs
@@ -85,14 +85,13 @@ namespace CosmosExplorer.UI
 
                 SharedProperties.SavedConnections.Add(connectionStringName, connectionString);
 
-                string exeDirectory = AppContext.BaseDirectory;
-                string filePath = Path.Combine(exeDirectory, SharedProperties.UserSettingsFileName);
+                string userSettingsPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CosmosExplorer", SharedProperties.UserSettingsFileName);
 
                 string savedConnections = JsonSerializer.Serialize(SharedProperties.SavedConnections, new JsonSerializerOptions { WriteIndented = true });
 
                 string encryptedSavedConnections = Utils.Encrypt(savedConnections, SharedProperties.Key, SharedProperties.IV);
 
-                File.WriteAllText(filePath, encryptedSavedConnections);
+                File.WriteAllText(userSettingsPath, encryptedSavedConnections);
 
                 if (Application.Current.MainWindow is MainWindow mainWindowInstance)
                 {


### PR DESCRIPTION
Update user settings file path and handling

Refactor user settings file path to use the local application
data folder instead of the executable directory. Add checks
to ensure the directory exists and initialize the file with
an empty string if it does not. This improves the robustness
of file handling for user settings in the CosmosExplorer.UI
namespace.