### PR TITLE
Refactor configuration management

### DIFF
--- a/src/CosmosExplorer.UI/App.config
+++ b/src/CosmosExplorer.UI/App.config
@@ -1,7 +1,6 @@
 ﻿<configuration>
 	<appSettings>
-		<add key="EncryptionKey" value="" />
-		<add key="EncryptionIV" value="" />
 		<add key="UserSettingsFile" value="UserSettings.config" />
+		<add key="CosmosExplorerConfig" value="CosmosExplorer.config" />
 	</appSettings>
 </configuration>

--- a/src/CosmosExplorer.UI/Common/SharedProperties.cs
+++ b/src/CosmosExplorer.UI/Common/SharedProperties.cs
@@ -1,4 +1,5 @@
 ﻿using System.Configuration;
+using System.IO;
 
 namespace CosmosExplorer.UI.Common
 {
@@ -6,8 +7,17 @@ namespace CosmosExplorer.UI.Common
     {
         static SharedProperties()
         {
-            Key = Convert.FromBase64String(ConfigurationManager.AppSettings["EncryptionKey"]);
-            IV = Convert.FromBase64String(ConfigurationManager.AppSettings["EncryptionIV"]);
+            string cosmosExplorerConfigFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "CosmosExplorer", ConfigurationManager.AppSettings["CosmosExplorerConfig"] ?? "CosmosExplorer.config");
+            if (File.Exists(cosmosExplorerConfigFilePath))
+            {
+                var config = ConfigurationManager.OpenMappedExeConfiguration(new ExeConfigurationFileMap { ExeConfigFilename = cosmosExplorerConfigFilePath }, ConfigurationUserLevel.None);
+                Key = Convert.FromBase64String(config.AppSettings.Settings["EncryptionKey"].Value);
+                IV = Convert.FromBase64String(config.AppSettings.Settings["EncryptionIV"].Value);
+            }
+            else
+            {
+                throw new Exception("CosmosExplorer.config is missing.");
+            }
 
             UserSettingsFileName = ConfigurationManager.AppSettings["UserSettingsFile"] ?? "UserSettings.config";
         }

--- a/src/CosmosExplorer.UI/Menu/File/ManageConnectionsModal.xaml
+++ b/src/CosmosExplorer.UI/Menu/File/ManageConnectionsModal.xaml
@@ -6,7 +6,7 @@
         mc:Ignorable="d"
         Title="Manage Connections" WindowStartupLocation="CenterScreen" Height="450" Width="800">
     <Grid>
-        <DataGrid x:Name="ConnectionsDataGrid" AutoGenerateColumns="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+        <DataGrid x:Name="ConnectionsDataGrid" AutoGenerateColumns="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" CanUserAddRows="False">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Connection Name" Binding="{Binding Name}" Width="720" FontSize="14" IsReadOnly="True"/>
                 <DataGridTemplateColumn Header="Actions" Width="Auto">


### PR DESCRIPTION
#### PR Classification
Refactor configuration management and UI behavior.

#### PR Summary
This pull request updates the configuration management for the Cosmos Explorer application by introducing a new configuration file and modifying how encryption keys are handled. It also enhances the UI by restricting user interactions with the data grid.
- `App.config`: Added `CosmosExplorerConfig` setting; removed `EncryptionKey` and `EncryptionIV` settings.
- `App.xaml.cs`: Changed configuration loading to use `CosmosExplorer.config` in the user's application data directory; updated error messages.
- `SharedProperties.cs`: Updated to retrieve `EncryptionKey` and `IV` from `CosmosExplorer.config`; throws an exception if the config file is missing.
- `ManageConnectionsModal.xaml`: Added `CanUserAddRows` property to `DataGrid`, preventing users from adding new rows.
