### PR TITLE
Add application icon to CosmosExplorer project

### DIFF
--- a/src/CosmosExplorer.UI/CosmosExplorer.UI.csproj
+++ b/src/CosmosExplorer.UI/CosmosExplorer.UI.csproj
@@ -6,7 +6,14 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
+    <ApplicationIcon>Icons\Cosmos-DB.ico</ApplicationIcon>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="Icons\Cosmos-DB.ico">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />


### PR DESCRIPTION
Add application icon to CosmosExplorer project

Updated `CosmosExplorer.UI.csproj` to include an application icon by adding the line `<ApplicationIcon>Icons\Cosmos-DB.ico</ApplicationIcon>`. A new `<ItemGroup>` was also created to ensure the icon file is copied to the output directory during the build process.