### PR TITLE
Add error handling and package metadata for Cosmos Explorer

### DIFF
--- a/assets/chocolatey/chocolateyinstall.ps1
+++ b/assets/chocolatey/chocolateyinstall.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = 'Stop' # stop on all errors
+
+$exePath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" + "\CosmosExplorer.UI.exe"
+$desktop = $([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::CommonDesktopDirectory))
+$desktopLink = Join-Path $desktop "Cosmos Explorer.lnk"
+
+Install-ChocolateyShortcut `
+    -shortcutFilePath $desktopLink `
+    -targetPath $exePath 

--- a/assets/chocolatey/chocolateyuninstall.ps1
+++ b/assets/chocolatey/chocolateyuninstall.ps1
@@ -1,0 +1,5 @@
+$ErrorActionPreference = 'Stop';
+
+$desktop = $([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::CommonDesktopDirectory))
+$desktopLink = Join-Path $desktop "Cosmos Explorer.lnk"
+Remove-Item $desktopLink -force -erroraction silentlycontinue

--- a/assets/chocolatey/nuspec
+++ b/assets/chocolatey/nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>cosmosexplorer</id>
+    <version>1.0.0</version>
+    <owners>Javier Leyes</owners>
+    <title>Cosmos Explorer</title>
+    <authors>Javier Leyes</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/javierleyes/CosmosExplorer/blob/main/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/javierleyes/CosmosExplorer</projectUrl>
+    <iconUrl>https://github.com/javierleyes/CosmosExplorer/blob/main/assets/images/Cosmos%20explorer.svg</iconUrl>
+    <packageSourceUrl>https://github.com/javierleyes/CosmosExplorer</packageSourceUrl>
+    <copyright>Copyright 2024 Javier Leyes</copyright>
+    <docsUrl>https://github.com/javierleyes/CosmosExplorer/tree/main/docs</docsUrl>
+    <bugTrackerUrl>https://github.com/javierleyes/CosmosExplorer/issues</bugTrackerUrl>
+    <tags>cosmosexplorer azure cosmos nosql</tags>
+    <summary>Cosmos Explorer allows users to manage data like Azure Portal</summary>
+    <description>Cosmos Explorer allows users to manage data like Azure Portal</description>
+    <releaseNotes>https://github.com/javierleyes/CosmosExplorer/blob/main/docs/release%20notes.md</releaseNotes>
+  </metadata>
+    <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>


### PR DESCRIPTION
Add error handling and package metadata for Cosmos Explorer

Enhance `chocolateyinstall.ps1` and `chocolateyuninstall.ps1` with error handling by setting `$ErrorActionPreference` to 'Stop'. Create a desktop shortcut for the application in the install script and ensure silent removal in the uninstall script.

Introduce a new `nuspec` file containing essential package metadata, including ID, version, authors, license, and project URLs, along with file specifications for the package.