### PR TITLE
Standardize font style in XAML windows

### DIFF
--- a/src/CosmosExplorer.UI/MainWindow.xaml
+++ b/src/CosmosExplorer.UI/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:av="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="av" x:Class="CosmosExplorer.UI.MainWindow"
         Title="Cosmos Explorer" Height="1000" Width="1900"
         Icon="/icons/Cosmos-DB.ico"
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen" FontFamily="Segoe UI" FontSize="14">
     <Grid>
         <Menu VerticalAlignment="Top">
             <MenuItem Header="File">

--- a/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml
+++ b/src/CosmosExplorer.UI/Menu/File/ConnectResourceGroupModal.xaml
@@ -1,7 +1,8 @@
 ﻿<Window x:Class="CosmosExplorer.UI.ConnectResourceGroupModal"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Enter the connection string" WindowStartupLocation="CenterScreen" Width="900" Height="260" ResizeMode="NoResize">
+        Title="Enter the connection string" WindowStartupLocation="CenterScreen" Width="900" Height="260" ResizeMode="NoResize"
+        FontFamily="Segoe UI" FontSize="14">
     <Grid>
         <StackPanel x:Name="ConnectionStringPanel" Height="220" Width="800" Orientation="Vertical">
             <Label Content="Enter the Account endpoint" FontSize="14" HorizontalAlignment="Left" Margin="5,10,0,0"/>

--- a/src/CosmosExplorer.UI/Menu/File/ManageConnectionsModal.xaml
+++ b/src/CosmosExplorer.UI/Menu/File/ManageConnectionsModal.xaml
@@ -4,7 +4,8 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
-        Title="Manage Connections" WindowStartupLocation="CenterScreen" Height="450" Width="800" ResizeMode="NoResize">
+        Title="Manage Connections" WindowStartupLocation="CenterScreen" Height="450" Width="800" ResizeMode="NoResize"
+        FontFamily="Segoe UI" FontSize="14">
     <Grid>
         <DataGrid x:Name="ConnectionsDataGrid" AutoGenerateColumns="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" CanUserAddRows="False">
             <DataGrid.Columns>

--- a/src/CosmosExplorer.UI/Menu/File/SaveConnectionStringModal.xaml
+++ b/src/CosmosExplorer.UI/Menu/File/SaveConnectionStringModal.xaml
@@ -1,7 +1,8 @@
 ﻿<Window x:Class="CosmosExplorer.UI.SaveConnectionStringModal"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Enter Connection String Name" WindowStartupLocation="CenterScreen" Width="400" Height="200" ResizeMode="NoResize">
+        Title="Enter Connection String Name" WindowStartupLocation="CenterScreen" Width="400" Height="200" ResizeMode="NoResize"
+        FontFamily="Segoe UI" FontSize="14">
     <Grid>
         <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
             <Label Content="Enter the name of the connection string" FontSize="14" HorizontalAlignment="Center" Margin="5"/>
@@ -9,4 +10,4 @@
             <Button Content="OK" Width="100" Margin="10" Click="OkButton_Click" FontSize="14" HorizontalAlignment="Center"/>
         </StackPanel>
     </Grid>
-</Window>    
+</Window>

--- a/src/CosmosExplorer.UI/Menu/Help/AboutWindow.xaml
+++ b/src/CosmosExplorer.UI/Menu/Help/AboutWindow.xaml
@@ -1,7 +1,8 @@
 ﻿<Window x:Class="CosmosExplorer.UI.AboutWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="About Cosmos Explorer" Height="500" Width="600" WindowStartupLocation="CenterScreen" ResizeMode="NoResize">
+        Title="About Cosmos Explorer" Height="500" Width="600" WindowStartupLocation="CenterScreen" ResizeMode="NoResize"
+        FontFamily="Segoe UI" FontSize="14">
     <Grid>
         <Grid.Background>
             <ImageBrush ImageSource="/Images/OrangeCatDeveloping.png" />

--- a/src/CosmosExplorer.UI/Modal/ConfirmationModal.xaml
+++ b/src/CosmosExplorer.UI/Modal/ConfirmationModal.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:CosmosExplorer.UI.Modal"
         mc:Ignorable="d"
         Title="Confirm delete" Height="150" Width="700"
-        WindowStartupLocation="CenterScreen" ResizeMode="NoResize">
+        WindowStartupLocation="CenterScreen" ResizeMode="NoResize" FontFamily="Segoe UI" FontSize="14">
     <Grid>
         <TextBlock Text="Are you sure you want to delete the selected item?" 
                    HorizontalAlignment="Center" VerticalAlignment="Center" 


### PR DESCRIPTION
Standardize font style in XAML windows

Added FontFamily="Segoe UI" and FontSize="14" attributes
to the <Window> elements across multiple XAML files.
This enhances visual consistency while keeping
WindowStartupLocation unchanged. Affected files include:
MainWindow.xaml, ConnectResourceGroupModal.xaml,
ManageConnectionsModal.xaml, SaveConnectionStringModal.xaml,
AboutWindow.xaml, and ConfirmationModal.xaml.