### PR TITLE
Adjust UI component sizes and margins

### DIFF
--- a/src/CosmosExplorer.UI/MainWindow.xaml
+++ b/src/CosmosExplorer.UI/MainWindow.xaml
@@ -75,7 +75,7 @@
                 </TreeView>
             </StackPanel>
 
-            <StackPanel x:Name="CenterPanel" Orientation="Vertical" VerticalAlignment="Top" Width="1550" Height="860" Margin="20,0,0,0">
+            <StackPanel x:Name="CenterPanel" Orientation="Vertical" VerticalAlignment="Top" Width="1550" Height="900" Margin="20,0,0,0">
 
                 <StackPanel x:Name="ToolBar" Width="1550" Height="40" HorizontalAlignment="Left" Orientation="Horizontal" Margin="0,0,0,10">
                     <Button x:Name="NewItemButton" Content="New Item" Width="100" Click="NewItem_Click" Height="30" FontSize="14" IsEnabled="False" Margin="0,0,10,0"/>
@@ -91,9 +91,9 @@
                     <Button Content="Apply filter" Width="100" Click="FilterButton_Click" Height="30" FontSize="14"/>
                 </StackPanel>
 
-                <StackPanel x:Name="Items" Orientation="Horizontal" Width="1550" Height="780" IsEnabled="False" Margin="0,10,0,0">
+                <StackPanel x:Name="Items" Orientation="Horizontal" Width="1550" Height="780" IsEnabled="False" Margin="0,0,0,0">
 
-                    <ListView x:Name="ItemListView" Width="530" Height="760" SelectionChanged="ItemsListView_SelectionChanged" av:ItemsSource="{av:SampleData ItemCount=5}">
+                    <ListView x:Name="ItemListView" Width="530" Height="746" SelectionChanged="ItemsListView_SelectionChanged" av:ItemsSource="{av:SampleData ItemCount=5}">
                         <ListView.View>
                             <GridView>
                                 <GridViewColumn Header="Id" DisplayMemberBinding="{Binding Id}" Width="260"/>
@@ -102,7 +102,7 @@
                         </ListView.View>
                     </ListView>
 
-                    <RichTextBox x:Name="ItemDescriptionRichTextBox" Width="1010" Height="760" Margin="10,0,0,0" FontSize="14" IsEnabled="False" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" TextChanged="ItemDescriptionRichTextBox_TextChanged" />
+                    <RichTextBox x:Name="ItemDescriptionRichTextBox" Width="1010" Height="746" Margin="10,0,0,0" FontSize="14" IsEnabled="False" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" TextChanged="ItemDescriptionRichTextBox_TextChanged" />
                 </StackPanel>
 
             </StackPanel>


### PR DESCRIPTION
Adjust UI component sizes and margins

- Increased height of `CenterPanel` from 860 to 900.
- Updated margin of `Items` StackPanel to "0,0,0,0".
- Decreased height of `ItemListView` and `ItemDescriptionRichTextBox` from 760 to 746.